### PR TITLE
Fix check recipe so it won't hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,7 @@ check:  ## CI blocks merge until this passes. If this fails, run "make check" lo
 	@go mod tidy
 	@if [ ! -z "`git status -s`" ]; then \
 		echo "The following differences will fail CI until committed:"; \
-		git diff; \
-		exit 1; \
+		git diff --exit-code; \
 	fi
 
 .PHONY: clean


### PR DESCRIPTION
With the large diff, `git diff` hangs until we see the end of the diff which cannot happen on CI