### PR TITLE
Adds -q/--fast-read from tar

### DIFF
--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -29,10 +29,10 @@ func TestList(t *testing.T) {
 	platform := "linux/amd64"
 
 	tests := []struct {
-		name                     string
-		patterns                 []string
-		verbose, veryVerbose     bool
-		expectedOut, expectedErr string
+		name                           string
+		patterns                       []string
+		fastRead, verbose, veryVerbose bool
+		expectedOut, expectedErr       string
 	}{
 		{
 			name: "normal",
@@ -52,12 +52,26 @@ Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 		{
-			name:     "one patternmatcher match",
+			name:     "one pattern matches",
 			patterns: []string{"usr/local/bin/*", "/etc"},
 			expectedOut: `usr/local/bin/boat
 usr/local/bin/car
 `,
 			expectedErr: "/etc not found in layer",
+		},
+		{
+			name:     "not fast match",
+			patterns: []string{"usr/local/bin/*"},
+			expectedOut: `usr/local/bin/boat
+usr/local/bin/car
+`,
+		},
+		{
+			name:     "fast match",
+			fastRead: true,
+			patterns: []string{"usr/local/bin/*"},
+			expectedOut: `usr/local/bin/boat
+`,
 		},
 		{
 			name:    "verbose",
@@ -96,6 +110,7 @@ CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
 				fake.NewRegistry(ctx, "ghcr.io", "tetratelabs/car"),
 				stdout,
 				tc.patterns,
+				tc.fastRead,
 				tc.verbose,
 				tc.veryVerbose,
 			)

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -84,6 +84,7 @@ func newApp(newRegistry internal.NewRegistry) *cli.App {
 				newRegistry(c.Context, domain, path),
 				c.App.Writer,
 				c.Args().Slice(),
+				c.Bool(flagFastRead),
 				c.Bool(flagVerbose),
 				c.Bool(flagVeryVerbose),
 			)

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	flagExtract     = "extract"
+	flagFastRead    = "fast-read"
 	flagList        = "list"
 	flagPlatform    = "platform"
 	flagReference   = "reference"
@@ -61,6 +62,11 @@ func flags() []cli.Flag {
 			Aliases: []string{"v"},
 			Usage: "Produce verbose output. In extract mode, this will list each file name as it is extracted." +
 				"In list mode, this produces output similar to ls.",
+		},
+		&cli.BoolFlag{
+			Name:    flagFastRead,
+			Aliases: []string{"q"},
+			Usage:   "Extract or list only the first archive entry that matches each pattern or filename operand.",
 		},
 		&cli.BoolFlag{
 			Name:    flagVeryVerbose,
@@ -111,6 +117,7 @@ func unBundleFlags(args []string) []string {
 		}
 		a = unBundleFlag(a, "vv", &result)
 		a = unBundleFlag(a, "v", &result)
+		a = unBundleFlag(a, "q", &result)
 		switch a {
 		case "":
 			continue

--- a/internal/cmd/flags_test.go
+++ b/internal/cmd/flags_test.go
@@ -30,6 +30,11 @@ func TestUnBundleFlags(t *testing.T) {
 			name: "empty",
 		},
 		{
+			name:     "-q not bundled",
+			input:    []string{"-q"},
+			expected: []string{"-q"},
+		},
+		{
 			name:     "-v not bundled",
 			input:    []string{"-v"},
 			expected: []string{"-v"},
@@ -63,6 +68,16 @@ func TestUnBundleFlags(t *testing.T) {
 			name:     "-tvvf",
 			input:    []string{"-tvvf"},
 			expected: []string{"-vv", "-t", "-f"},
+		},
+		{
+			name:     "-qtvvf",
+			input:    []string{"-qtvvf"},
+			expected: []string{"-vv", "-q", "-t", "-f"},
+		},
+		{
+			name:     "-tqvvf",
+			input:    []string{"-tqvvf"},
+			expected: []string{"-vv", "-q", "-t", "-f"},
 		},
 		{
 			name:     "-xvf",

--- a/internal/patternmatcher/patternmatcher.go
+++ b/internal/patternmatcher/patternmatcher.go
@@ -22,17 +22,20 @@ import (
 type PatternMatcher interface {
 	// MatchesPattern is like filepath.Match, but returns true if any enclosed patterns match.
 	MatchesPattern(name string) bool
+	// StillMatching returns true unless all required patterns are matched.
+	StillMatching() bool
 	// Unmatched returns non-empty if MatchesPattern hasn't matched all patterns, yet.
 	Unmatched() []string
 }
 
 type patternMatcher struct {
 	patterns map[string]bool
+	fastRead bool
 }
 
 // New returns a possibly no-op PatternMatcher based on the inputs
-func New(patterns []string) PatternMatcher {
-	pm := &patternMatcher{patterns: map[string]bool{}}
+func New(patterns []string, fastRead bool) PatternMatcher {
+	pm := &patternMatcher{patterns: map[string]bool{}, fastRead: fastRead}
 	for _, pattern := range patterns {
 		pm.patterns[pattern] = false
 	}
@@ -50,6 +53,10 @@ func (pm *patternMatcher) MatchesPattern(name string) bool {
 		}
 	}
 	return false
+}
+
+func (pm *patternMatcher) StillMatching() bool {
+	return !pm.fastRead || len(pm.patterns) == 0 || len(pm.Unmatched()) > 0
 }
 
 func (pm *patternMatcher) Unmatched() []string {

--- a/internal/patternmatcher/patternmatcher_test.go
+++ b/internal/patternmatcher/patternmatcher_test.go
@@ -33,24 +33,24 @@ func TestMatchesPattern(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "no patternmatcher matches",
+			name:     "no pattern matches",
 			input:    "usr/local/bin/car",
 			patterns: []string{"usr/local/sbin", "etc"},
 		},
 		{
-			name:     "only patternmatcher matches (exact)",
+			name:     "only pattern matches (exact)",
 			input:    "usr/local/bin/car",
 			patterns: []string{"usr/local/bin/car"},
 			expected: true,
 		},
 		{
-			name:     "only patternmatcher matches (glob)",
+			name:     "only pattern matches (glob)",
 			input:    "usr/local/bin/car",
 			patterns: []string{"usr/local/bin/*"},
 			expected: true,
 		},
 		{
-			name:     "one patternmatcher matches",
+			name:     "one pattern matches",
 			input:    "usr/local/bin/car",
 			patterns: []string{"usr/local/bin/*", "etc"},
 			expected: true,
@@ -61,8 +61,62 @@ func TestMatchesPattern(t *testing.T) {
 		tc := tc // pin! see https://github.com/kyoh86/scopelint for why
 
 		t.Run(tc.name, func(t *testing.T) {
-			pm := New(tc.patterns)
+			pm := New(tc.patterns, false)
 			require.Equal(t, tc.expected, pm.MatchesPattern(tc.input))
+		})
+	}
+}
+
+func TestStillMatching(t *testing.T) {
+	tests := []struct {
+		name             string
+		patterns, inputs []string
+		expected         bool
+	}{
+		{
+			name:     "no patterns",
+			inputs:   []string{"usr/local/bin/car"},
+			expected: true,
+		},
+		{
+			name:     "no pattern matches",
+			patterns: []string{"usr/local/bin", "etc"},
+			inputs:   []string{"usr/local/bin/car"},
+			expected: true,
+		},
+		{
+			name:     "only pattern matches (exact)",
+			patterns: []string{"usr/local/bin/car"},
+			inputs:   []string{"usr/local/bin/car"},
+		},
+		{
+			name:     "only pattern matches (glob)",
+			patterns: []string{"usr/local/bin/*"},
+			inputs:   []string{"usr/local/bin/car"},
+		},
+		{
+			name:     "one pattern matches",
+			patterns: []string{"usr/local/bin/*", "etc"},
+			inputs:   []string{"usr/local/bin/car"},
+			expected: true,
+		},
+		{
+			name:     "all patterns match",
+			patterns: []string{"usr/local/bin/*", "usr/local/bin/car"},
+			inputs:   []string{"usr/local/bin/car"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // pin! see https://github.com/kyoh86/scopelint for why
+
+		t.Run(tc.name, func(t *testing.T) {
+			pm := New(tc.patterns, true)
+			for _, p := range tc.inputs {
+				pm.MatchesPattern(p)
+			}
+			require.Equal(t, tc.expected, pm.StillMatching())
 		})
 	}
 }


### PR DESCRIPTION
This helps reduce scanning of layers when inputs are explicit.

before
```bash
$./car  -tvvf envoyproxy/envoy-windows:v1.18.3 'Files/Program Files/envoy/envoy.exe'
https://index.docker.io/v2/envoyproxy/envoy-windows/manifests/v1.18.3 platform=windows/amd64 totalLayerSize: 13634055
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:47916aee02007e0e175e80deb2938cf8f95457b9abb555bd44dc461680dc552c size=323887
CreatedBy: cmd /S /C mkdir "C:\\Program\ Files\\envoy"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:ba79ee4428b5ceec3026664126a146fd8c1041b478f3018ec0c90b78d7fe6355 size=331919
CreatedBy: cmd /S /C setx path "%path%;c:\Program Files\envoy"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4 size=12217107
CreatedBy: cmd /S /C #(nop) ADD file:61df7bfb8255c0673d4ed25f961df5121141ee800202081e549fc36828624577 in C:\Program Files\envoy\
----------	33538560	May 12 06:32:28	Files/Program Files/envoy/envoy.exe
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:0fcfdc906e922391139a1c2d8f5d600066fa3b21c720a4024831471e2a8f0011 size=337530
CreatedBy: cmd /S /C mkdir "C:\\ProgramData\\envoy"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:f5ece8fbad694f5d1169c17ddd4217265cdf3dd886b71a8e9144f8b00e22de07 size=2410
CreatedBy: cmd /S /C #(nop) ADD file:59ef68147ad4a3f10999e2e334cf60397fbcc6501b3949dd811afd7b8f03ca43 in C:\ProgramData\envoy\envoy.yaml
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:8d3db7768af4371ec3f749f6816c8450687e276a883b8ca626a1fc1402fd32e0 size=419457
CreatedBy: cmd /S /C powershell -Command "(cat C:\ProgramData\envoy\envoy.yaml -raw) -replace '/tmp/','C:\Windows\Temp\' | Set-Content -Encoding Ascii C:\ProgramData\envoy\envoy.yaml"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:9e17bb8cfb82c53b1793341a2dfb555e63088b1594d81d2b01106fae9a8aa60b size=1745
CreatedBy: cmd /S /C #(nop) COPY file:4e78f00367722220f515590585490fc6d785cc05e3a59a54f965431fa3ef374e in C:\
```

after:
```bash:
$ ./car  -qtvvf envoyproxy/envoy-windows:v1.18.3 'Files/Program Files/envoy/envoy.exe'
https://index.docker.io/v2/envoyproxy/envoy-windows/manifests/v1.18.3 platform=windows/amd64 totalLayerSize: 13634055
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:47916aee02007e0e175e80deb2938cf8f95457b9abb555bd44dc461680dc552c size=323887
CreatedBy: cmd /S /C mkdir "C:\\Program\ Files\\envoy"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:ba79ee4428b5ceec3026664126a146fd8c1041b478f3018ec0c90b78d7fe6355 size=331919
CreatedBy: cmd /S /C setx path "%path%;c:\Program Files\envoy"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4 size=12217107
CreatedBy: cmd /S /C #(nop) ADD file:61df7bfb8255c0673d4ed25f961df5121141ee800202081e549fc36828624577 in C:\Program Files\envoy\
----------	33538560	May 12 06:32:28	Files/Program Files/envoy/envoy.exe
```

Signed-off-by: Adrian Cole <adrian@tetrate.io>