### PR TITLE
Adds --layer-pattern to constrain to dockerfile instructions

### DIFF
--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -43,15 +43,11 @@ type car struct {
 }
 
 // New creates a new instance of Car
-func New(registry internal.Registry, out io.Writer, layerPattern string, patterns []string, fastRead, verbose, veryVerbose bool) Car {
-	var layerRegexp *regexp.Regexp
-	if layerPattern != "" {
-		layerRegexp = regexp.MustCompile(layerPattern)
-	}
+func New(registry internal.Registry, out io.Writer, layerPattern *regexp.Regexp, patterns []string, fastRead, verbose, veryVerbose bool) Car {
 	return &car{
 		registry:     registry,
 		out:          out,
-		layerPattern: layerRegexp,
+		layerPattern: layerPattern,
 		filePatterns: patterns,
 		fastRead:     fastRead,
 		verbose:      verbose || veryVerbose,

--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -17,6 +17,7 @@ package car
 import (
 	"bytes"
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,7 @@ func TestList(t *testing.T) {
 	tests := []struct {
 		name                           string
 		patterns                       []string
-		layerPattern                   string
+		layerPattern                   *regexp.Regexp
 		fastRead, verbose, veryVerbose bool
 		expectedOut, expectedErr       string
 	}{
@@ -89,7 +90,7 @@ CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 		},
 		{
 			name:         "layer pattern",
-			layerPattern: `ADD build`,
+			layerPattern: regexp.MustCompile(`ADD build`),
 			expectedOut: `usr/local/bin/car
 `,
 		},

--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -31,6 +31,7 @@ func TestList(t *testing.T) {
 	tests := []struct {
 		name                           string
 		patterns                       []string
+		layerPattern                   string
 		fastRead, verbose, veryVerbose bool
 		expectedOut, expectedErr       string
 	}{
@@ -43,7 +44,7 @@ Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 		{
-			name:     "all patterns match",
+			name:     "all filePatterns match",
 			patterns: []string{"bin/bash", "usr/local/bin/*", "Files/ProgramData/truck/bin/*"},
 			expectedOut: `bin/bash
 usr/local/bin/boat
@@ -71,6 +72,25 @@ usr/local/bin/car
 			fastRead: true,
 			patterns: []string{"usr/local/bin/*"},
 			expectedOut: `usr/local/bin/boat
+`,
+		},
+		{
+			name:        "fast match, very verbose",
+			fastRead:    true,
+			veryVerbose: true,
+			patterns:    []string{"usr/local/bin/car"},
+			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 32697009
+fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=26697009
+CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / 
+fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=2000000
+CreatedBy: ADD build/* /usr/local/bin/ # buildkit
+-rwxr-xr-x	4000000	May 12 03:53:29	usr/local/bin/car
+`,
+		},
+		{
+			name:         "layer pattern",
+			layerPattern: `ADD build`,
+			expectedOut: `usr/local/bin/car
 `,
 		},
 		{
@@ -109,6 +129,7 @@ CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
 			c := New(
 				fake.NewRegistry(ctx, "ghcr.io", "tetratelabs/car"),
 				stdout,
+				tc.layerPattern,
 				tc.patterns,
 				tc.fastRead,
 				tc.verbose,

--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -45,7 +45,7 @@ Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 		{
-			name:     "all filePatterns match",
+			name:     "all patterns match",
 			patterns: []string{"bin/bash", "usr/local/bin/*", "Files/ProgramData/truck/bin/*"},
 			expectedOut: `bin/bash
 usr/local/bin/boat

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 
 	"github.com/urfave/cli/v2"
 
@@ -60,6 +61,7 @@ func logUsageError(name string, stderr io.Writer) {
 
 func newApp(newRegistry internal.NewRegistry) *cli.App {
 	var domain, path, tag, platform string
+	var layerPattern *regexp.Regexp
 	a := &cli.App{
 		Name:     "car",
 		Usage:    "car is like tar, but for containers!",
@@ -77,13 +79,14 @@ func newApp(newRegistry internal.NewRegistry) *cli.App {
 			if err != nil {
 				return err
 			}
-			return nil
+			layerPattern, err = validateLayerPatternFlag(c.String(flagLayerPattern))
+			return err
 		},
 		Action: func(c *cli.Context) error {
 			car := carutil.New(
 				newRegistry(c.Context, domain, path),
 				c.App.Writer,
-				c.String(flagLayerPattern),
+				layerPattern,
 				c.Args().Slice(),
 				c.Bool(flagFastRead),
 				c.Bool(flagVerbose),

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -83,6 +83,7 @@ func newApp(newRegistry internal.NewRegistry) *cli.App {
 			car := carutil.New(
 				newRegistry(c.Context, domain, path),
 				c.App.Writer,
+				c.String(flagLayerPattern),
 				c.Args().Slice(),
 				c.Bool(flagFastRead),
 				c.Bool(flagVerbose),

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -74,20 +74,35 @@ Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 		{
-			name: "list matches patternmatcher",
+			name: "list matches pattern",
 			args: []string{"car", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/*"},
 			expectedStdout: `usr/local/bin/boat
 usr/local/bin/car
 `,
 		},
 		{
-			name:           "list doesn't match patternmatcher",
+			name:           "list doesn't match pattern",
 			args:           []string{"car", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/*", "robots"},
 			expectedStatus: 1,
 			expectedStdout: `usr/local/bin/boat
 usr/local/bin/car
 `,
 			expectedStderr: `error: robots not found in layer
+`,
+		},
+		{
+			name: "list matches layer-pattern",
+			args: []string{"car", "--layer-pattern", "ADD", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/*"},
+			expectedStdout: `usr/local/bin/boat
+usr/local/bin/car
+`,
+		},
+		{
+			name:           "list doesn't match layer-pattern",
+			args:           []string{"car", "--layer-pattern", "/bin/sh", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/car"},
+			expectedStatus: 1,
+			expectedStdout: ``,
+			expectedStderr: `error: usr/local/bin/car not found in layer
 `,
 		},
 	}

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -25,13 +25,14 @@ import (
 )
 
 const (
-	flagExtract     = "extract"
-	flagFastRead    = "fast-read"
-	flagList        = "list"
-	flagPlatform    = "platform"
-	flagReference   = "reference"
-	flagVerbose     = "verbose"
-	flagVeryVerbose = "very-verbose"
+	flagExtract      = "extract"
+	flagFastRead     = "fast-read"
+	flagLayerPattern = "layer-pattern"
+	flagList         = "list"
+	flagPlatform     = "platform"
+	flagReference    = "reference"
+	flagVerbose      = "verbose"
+	flagVeryVerbose  = "very-verbose"
 )
 
 // flags is a function instead of a var to avoid unit tests tainting each-other (cli.Flag contains state).
@@ -46,6 +47,10 @@ func flags() []cli.Flag {
 			Name:    flagList,
 			Aliases: []string{"t"},
 			Usage:   "List image filesystem layers to stdout.",
+		},
+		&cli.StringFlag{
+			Name:  flagLayerPattern,
+			Usage: "regular expression to match the 'created_by' field of image layers",
 		},
 		&cli.StringFlag{
 			Name:  flagPlatform,

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -79,6 +80,18 @@ func flags() []cli.Flag {
 			Usage:   "Produce very verbose output. This produces arg header for each image layer and file details similar to ls.",
 		},
 	}
+}
+
+func validateLayerPatternFlag(layerPattern string) (*regexp.Regexp, error) {
+	if layerPattern == "" {
+		return nil, nil
+	}
+
+	p, err := regexp.Compile(layerPattern)
+	if err != nil {
+		return nil, &validationError{fmt.Sprintf("invalid [%s] flag: %s", flagLayerPattern, err)}
+	}
+	return p, nil
 }
 
 func validatePlatformFlag(platform string) (string, error) {

--- a/internal/cmd/flags_test.go
+++ b/internal/cmd/flags_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -101,6 +102,33 @@ func TestUnBundleFlags(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expected, unBundleFlags(tc.input))
+		})
+	}
+}
+
+func TestValidateLayerPattern(t *testing.T) {
+	tests := []struct {
+		name            string
+		expectedPattern *regexp.Regexp
+		expectedErr     string
+	}{
+		{name: ``},
+		{name: `ADD`, expectedPattern: regexp.MustCompile(`ADD`)},
+		{name: `ADD.*envoy`, expectedPattern: regexp.MustCompile(`ADD.*envoy`)},
+		{name: `(`, expectedErr: "invalid [layer-pattern] flag: error parsing regexp: missing closing ): `(`"},
+	}
+
+	for _, tc := range tests {
+		tc := tc // pin! see https://github.com/kyoh86/scopelint for why
+
+		t.Run(tc.name, func(t *testing.T) {
+			layerPattern, err := validateLayerPatternFlag(tc.name)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedPattern, layerPattern)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This saves bandwidth and time by allowing you to specify the layers
likely to contain your data based on Dockerfile instructions
(created_by).

without
```
$ ./car  -qtvvf envoyproxy/envoy-windows:v1.18.3 'Files/Program Files/envoy/envoy.exe'
https://index.docker.io/v2/envoyproxy/envoy-windows/manifests/v1.18.3 platform=windows/amd64 totalLayerSize: 13634055
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:47916aee02007e0e175e80deb2938cf8f95457b9abb555bd44dc461680dc552c size=323887
CreatedBy: cmd /S /C mkdir "C:\\Program\ Files\\envoy"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:ba79ee4428b5ceec3026664126a146fd8c1041b478f3018ec0c90b78d7fe6355 size=331919
CreatedBy: cmd /S /C setx path "%path%;c:\Program Files\envoy"
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4 size=12217107
CreatedBy: cmd /S /C #(nop) ADD file:61df7bfb8255c0673d4ed25f961df5121141ee800202081e549fc36828624577 in C:\Program Files\envoy\
----------	33538560	May 12 06:32:28	Files/Program Files/envoy/envoy.exe
```

now
```bash
$ ./car --layer-pattern ADD -qtvvf envoyproxy/envoy-windows:v1.18.3 'Files/Program Files/envoy/envoy.exe'
https://index.docker.io/v2/envoyproxy/envoy-windows/manifests/v1.18.3 platform=windows/amd64 totalLayerSize: 13634055
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4 size=12217107
CreatedBy: cmd /S /C #(nop) ADD file:61df7bfb8255c0673d4ed25f961df5121141ee800202081e549fc36828624577 in C:\Program Files\envoy\
----------	33538560	May 12 06:32:28	Files/Program Files/envoy/envoy.exe
```

Signed-off-by: Adrian Cole <adrian@tetrate.io>