### PR TITLE
Adds extract commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ built for. For example, you can extract files from a `windows/amd64` image even 
 
 ## Experimental!
 
-Right now, only list works:
-
 ```bash
 $ go build .
 

--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -109,7 +109,7 @@ func (c *car) Extract(ctx context.Context, tag, platform, directory string, stri
 			if err := os.MkdirAll(baseDir, 0755); err != nil { //nolint:gosec
 				return err
 			}
-			dirsCreated[baseDir] = true
+			dirsCreated[baseDir] = struct{}{}
 		}
 		fw, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_RDWR, mode) //nolint:gosec
 		if err != nil {

--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -29,50 +31,52 @@ import (
 
 // Car is like tar, except for containers.
 type Car interface {
-	// List prints any files not-filtered from the image layers of the given tag and platform.
+	// List prints any non-filtered files from the image layers of the given tag and platform.
 	List(ctx context.Context, tag, platform string) error
+	// Extract writes any non-filtered files from the image layers of the given tag and platform into the directory.
+	// * directory must be absolute, though may be absent
+	//
+	// stripComponents strips the base directory of each internal.ReadFile call by the associated count.
+	//   Ex directory=v1.0, stripComponents=1, name=/usr/bin/tar -> v1.0/bin/tar
+	//   Ex directory=v1.0, stripComponents=2, name=/usr/bin/tar -> v1.0/tar
+	//   Ex directory=v1.0, stripComponents=4, name=/usr/bin/tar -> ignored because too many path components
+	Extract(ctx context.Context, tag, platform, directory string, stripComponents int) error
 }
 
 type car struct {
-	registry     internal.Registry
-	out          io.Writer
-	layerPattern *regexp.Regexp
+	registry         internal.Registry
+	out              io.Writer
+	createdByPattern *regexp.Regexp
 	// filePatterns just like tar. Ex "car -tf image:tag foo/* bar.txt"
 	filePatterns                   []string
 	fastRead, verbose, veryVerbose bool
 }
 
 // New creates a new instance of Car
-func New(registry internal.Registry, out io.Writer, layerPattern *regexp.Regexp, patterns []string, fastRead, verbose, veryVerbose bool) Car {
+func New(registry internal.Registry, out io.Writer, createdByPattern *regexp.Regexp, patterns []string, fastRead, verbose, veryVerbose bool) Car {
 	return &car{
-		registry:     registry,
-		out:          out,
-		layerPattern: layerPattern,
-		filePatterns: patterns,
-		fastRead:     fastRead,
-		verbose:      verbose || veryVerbose,
-		veryVerbose:  veryVerbose,
+		registry:         registry,
+		out:              out,
+		createdByPattern: createdByPattern,
+		filePatterns:     patterns,
+		fastRead:         fastRead,
+		verbose:          verbose || veryVerbose,
+		veryVerbose:      veryVerbose,
 	}
 }
-func (c *car) List(ctx context.Context, tag, platform string) error {
+
+func (c *car) do(ctx context.Context, readFile internal.ReadFile, tag, platform string) error {
 	filteredLayers, err := c.getFilesystemLayers(ctx, tag, platform)
 	if err != nil {
 		return err
 	}
-
 	pm := patternmatcher.New(c.filePatterns, c.fastRead)
-	rf := func(name string, size int64, mode os.FileMode, modTime time.Time, _ io.Reader) error {
+	rf := func(name string, size int64, mode os.FileMode, modTime time.Time, reader io.Reader) error {
 		if !pm.MatchesPattern(name) {
 			return nil
 		}
-		if c.verbose {
-			fmt.Fprintf(c.out, "%s\t%d\t%s\t%s\n", mode, size, modTime.Format(time.Stamp), name)
-		} else {
-			fmt.Fprintln(c.out, name)
-		}
-		return nil
+		return readFile(name, size, mode, modTime, reader)
 	}
-
 	for _, layer := range filteredLayers {
 		if c.veryVerbose {
 			fmt.Fprintln(c.out, layer.String()) //nolint
@@ -84,12 +88,70 @@ func (c *car) List(ctx context.Context, tag, platform string) error {
 			break
 		}
 	}
-
 	unmatched := pm.Unmatched()
 	if len(unmatched) > 0 {
 		return fmt.Errorf("%s not found in layer", strings.Join(unmatched, ", "))
 	}
 	return nil
+}
+
+func (c *car) Extract(ctx context.Context, tag, platform, directory string, stripComponents int) error {
+	// maintain a lazy map of directories already created
+	dirsCreated := map[string]bool{}
+	return c.do(ctx, func(name string, size int64, mode os.FileMode, modTime time.Time, reader io.Reader) error {
+		destinationPath, ok := newDestinationPath(name, directory, stripComponents)
+		if !ok {
+			return nil // skip
+		}
+
+		baseDir := path.Dir(destinationPath)
+		if ok := dirsCreated[baseDir]; !ok {
+			if err := os.MkdirAll(baseDir, 0755); err != nil { //nolint:gosec
+				return err
+			}
+			dirsCreated[baseDir] = true
+		}
+		fw, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_RDWR, mode) //nolint:gosec
+		if err != nil {
+			return err
+		}
+		if c.veryVerbose {
+			c.listVerbose(name, size, mode, modTime)
+		} else if c.verbose {
+			fmt.Fprintln(c.out, name)
+		}
+		_, err = io.CopyN(fw, reader, size)
+		return err
+	}, tag, platform)
+}
+
+func newDestinationPath(name, directory string, stripComponents int) (string, bool) {
+	i := 0
+	for ; stripComponents > 0 && i < len(name); i++ {
+		if os.IsPathSeparator(name[i]) {
+			stripComponents--
+		}
+	}
+	// if the dirname length is longer than strip components, skip
+	if stripComponents > 0 {
+		return "", false
+	}
+	return filepath.Join(directory, name[i:]), true
+}
+
+func (c *car) List(ctx context.Context, tag, platform string) error {
+	return c.do(ctx, func(name string, size int64, mode os.FileMode, modTime time.Time, _ io.Reader) error {
+		if c.verbose {
+			c.listVerbose(name, size, mode, modTime)
+		} else {
+			fmt.Fprintln(c.out, name)
+		}
+		return nil
+	}, tag, platform)
+}
+
+func (c *car) listVerbose(name string, size int64, mode os.FileMode, modTime time.Time) {
+	fmt.Fprintf(c.out, "%s\t%d\t%s\t%s\n", mode, size, modTime.Format(time.Stamp), name) //nolint
 }
 
 func (c *car) getFilesystemLayers(ctx context.Context, tag, platform string) ([]*internal.FilesystemLayer, error) {
@@ -102,7 +164,7 @@ func (c *car) getFilesystemLayers(ctx context.Context, tag, platform string) ([]
 	}
 	filteredLayers := make([]*internal.FilesystemLayer, 0, len(img.FilesystemLayers))
 	for _, layer := range img.FilesystemLayers {
-		if c.layerPattern == nil || c.layerPattern.MatchString(layer.CreatedBy) {
+		if c.createdByPattern == nil || c.createdByPattern.MatchString(layer.CreatedBy) {
 			filteredLayers = append(filteredLayers, layer)
 		}
 	}

--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -97,7 +97,7 @@ func (c *car) do(ctx context.Context, readFile internal.ReadFile, tag, platform 
 
 func (c *car) Extract(ctx context.Context, tag, platform, directory string, stripComponents int) error {
 	// maintain a lazy map of directories already created
-	dirsCreated := map[string]bool{}
+	dirsCreated := map[string]struct{}{}
 	return c.do(ctx, func(name string, size int64, mode os.FileMode, modTime time.Time, reader io.Reader) error {
 		destinationPath, ok := newDestinationPath(name, directory, stripComponents)
 		if !ok {

--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -105,7 +105,7 @@ func (c *car) Extract(ctx context.Context, tag, platform, directory string, stri
 		}
 
 		baseDir := path.Dir(destinationPath)
-		if ok := dirsCreated[baseDir]; !ok {
+		if _, ok := dirsCreated[baseDir]; !ok {
 			if err := os.MkdirAll(baseDir, 0755); err != nil { //nolint:gosec
 				return err
 			}

--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -115,7 +115,8 @@ func (c *car) Extract(ctx context.Context, tag, platform, directory string, stri
 		if err != nil {
 			return err
 		}
-		if c.veryVerbose {
+
+		if c.veryVerbose { // extract veryVerbose = list verbose. In other words, tar -xvv output is the same as tar -tv
 			c.listVerbose(name, size, mode, modTime)
 		} else if c.verbose {
 			fmt.Fprintln(c.out, name)
@@ -125,6 +126,8 @@ func (c *car) Extract(ctx context.Context, tag, platform, directory string, stri
 	}, tag, platform)
 }
 
+// newDestinationPath allows manipulation of the output path based on flags like `--strip-components`
+// This returns the output path and a boolean which indicates if the file should be skipped or not.
 func newDestinationPath(name, directory string, stripComponents int) (string, bool) {
 	i := 0
 	for ; stripComponents > 0 && i < len(name); i++ {
@@ -132,7 +135,8 @@ func newDestinationPath(name, directory string, stripComponents int) (string, bo
 			stripComponents--
 		}
 	}
-	// if the dirname length is longer than strip components, skip
+	// If the dirname length is longer than strip components, skip. We don't warn because tar doesn't, probably because
+	// there could be many files skipped.
 	if stripComponents > 0 {
 		return "", false
 	}

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -27,8 +27,11 @@ import (
 )
 
 // validationError is arg marker of arg validation error vs an execution one.
-type validationError struct {
-	string
+type validationError struct{ string }
+
+// newValidationError formats a validationError
+func newValidationError(format string, a ...interface{}) error {
+	return &validationError{fmt.Sprintf(format, a...)}
 }
 
 // Error implements the error interface.
@@ -77,7 +80,7 @@ func newApp(newRegistry internal.NewRegistry) *cli.App {
 		Flags:    flags(),
 		HideHelp: true,
 		OnUsageError: func(c *cli.Context, err error, isSub bool) error {
-			return &validationError{err.Error()}
+			return newValidationError(err.Error())
 		},
 		Before: func(c *cli.Context) (err error) {
 			domain, path, tag, err = validateReferenceFlag(c.String(flagReference))
@@ -93,6 +96,9 @@ func newApp(newRegistry internal.NewRegistry) *cli.App {
 				return err
 			}
 			if c.Bool(flagExtract) {
+				if c.Bool(flagExtract) {
+					return newValidationError("you cannot combine flags [%s] and [%s]", flagList, flagExtract)
+				}
 				directory, err = validateDirectoryFlag(c.String(flagDirectory))
 				if err != nil {
 					return err

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -91,15 +91,15 @@ usr/local/bin/car
 `,
 		},
 		{
-			name: "list matches layer-pattern",
-			args: []string{"car", "--layer-pattern", "ADD", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/*"},
+			name: "list matches created-by-pattern",
+			args: []string{"car", "--created-by-pattern", "ADD", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/*"},
 			expectedStdout: `usr/local/bin/boat
 usr/local/bin/car
 `,
 		},
 		{
-			name:           "list doesn't match layer-pattern",
-			args:           []string{"car", "--layer-pattern", "/bin/sh", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/car"},
+			name:           "list doesn't match created-by-pattern",
+			args:           []string{"car", "--created-by-pattern", "/bin/sh", "-tf", "tetratelabs/car:v1.0", "usr/local/bin/car"},
 			expectedStatus: 1,
 			expectedStdout: ``,
 			expectedStderr: `error: usr/local/bin/car not found in layer

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -65,12 +65,21 @@ show usage with: car help
 `,
 		},
 		{
+			name:           "list and extract",
+			args:           []string{"car", "-t", "-xf", "tetratelabs/car:v1.0"},
+			expectedStatus: 1,
+			expectedStderr: `you cannot combine flags [list] and [extract]
+show usage with: car help
+`,
+		},
+		{
 			name: "list",
 			args: []string{"car", "-tf", "tetratelabs/car:v1.0"},
 			expectedStdout: `bin/apple.txt
 usr/local/bin/boat
 usr/local/bin/car
 Files/ProgramData/truck/bin/truck.exe
+usr/local/sbin/car
 `,
 		},
 		{

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -104,7 +104,7 @@ func validateCreatedByPatternFlag(createdByPattern string) (*regexp.Regexp, erro
 
 	p, err := regexp.Compile(createdByPattern)
 	if err != nil {
-		return nil, &validationError{fmt.Sprintf("invalid [%s] flag: %s", flagCreatedByPattern, err)}
+		return nil, newValidationError("invalid [%s] flag: %s", flagCreatedByPattern, err)
 	}
 	return p, nil
 }
@@ -115,7 +115,7 @@ func validateDirectoryFlag(directory string) (string, error) {
 	}
 	d, err := filepath.Abs(directory)
 	if err != nil {
-		return "", &validationError{fmt.Sprintf("invalid [%s] flag: %s", flagDirectory, err)}
+		return "", newValidationError("invalid [%s] flag: %s", flagDirectory, err)
 	}
 	return d, nil
 }
@@ -126,13 +126,13 @@ func validatePlatformFlag(platform string) (string, error) {
 	}
 	s := strings.Split(platform, "/")
 	if len(s) != 2 {
-		return "", &validationError{fmt.Sprintf("invalid [%s] flag: %q should be 2 / delimited fields", flagPlatform, platform)}
+		return "", newValidationError("invalid [%s] flag: %q should be 2 / delimited fields", flagPlatform, platform)
 	}
 	if !internal.IsValidOS(s[0]) {
-		return "", &validationError{fmt.Sprintf("invalid [%s] flag: %q has an invalid OS", flagPlatform, platform)}
+		return "", newValidationError("invalid [%s] flag: %q has an invalid OS", flagPlatform, platform)
 	}
 	if !internal.IsValidArch(s[1]) {
-		return "", &validationError{fmt.Sprintf("invalid [%s] flag: %q has an invalid architecture", flagPlatform, platform)}
+		return "", newValidationError("invalid [%s] flag: %q has an invalid architecture", flagPlatform, platform)
 	}
 	return platform, nil
 }
@@ -140,10 +140,10 @@ func validatePlatformFlag(platform string) (string, error) {
 func validateReferenceFlag(ref string) (domain, path, tag string, err error) {
 	name, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {
-		return "", "", "", &validationError{err.Error()}
+		return "", "", "", newValidationError(err.Error())
 	}
 	if _, ok := name.(reference.NamedTagged); !ok {
-		return "", "", "", &validationError{fmt.Sprintf("invalid [%s] flag: expected tagged reference", flagReference)}
+		return "", "", "", newValidationError("invalid [%s] flag: expected tagged reference", flagReference)
 	}
 	domain = reference.Domain(name)
 	path = reference.Path(name)
@@ -153,7 +153,7 @@ func validateReferenceFlag(ref string) (domain, path, tag string, err error) {
 
 func validateStripComponentsFlag(stripComponents int) (int, error) {
 	if stripComponents < 0 {
-		return 0, &validationError{fmt.Sprintf("invalid [%s] flag: must be a whole number", flagStripComponents)}
+		return 0, newValidationError("invalid [%s] flag: must be a whole number", flagStripComponents)
 	}
 	return stripComponents, nil
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -26,19 +28,31 @@ import (
 )
 
 const (
-	flagExtract      = "extract"
-	flagFastRead     = "fast-read"
-	flagLayerPattern = "layer-pattern"
-	flagList         = "list"
-	flagPlatform     = "platform"
-	flagReference    = "reference"
-	flagVerbose      = "verbose"
-	flagVeryVerbose  = "very-verbose"
+	flagCreatedByPattern = "created-by-pattern"
+	flagDirectory        = "directory"
+	flagExtract          = "extract"
+	flagFastRead         = "fast-read"
+	flagList             = "list"
+	flagPlatform         = "platform"
+	flagReference        = "reference"
+	flagStripComponents  = "strip-components"
+	flagVerbose          = "verbose"
+	flagVeryVerbose      = "very-verbose"
 )
 
 // flags is a function instead of a var to avoid unit tests tainting each-other (cli.Flag contains state).
 func flags() []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  flagCreatedByPattern,
+			Usage: "regular expression to match the 'created_by' field of image layers",
+		},
+		&cli.StringFlag{
+			Name:        flagDirectory,
+			Aliases:     []string{"C"},
+			DefaultText: ".",
+			Usage:       fmt.Sprintf("Change to [%s] before extracting files", flagDirectory),
+		},
 		&cli.BoolFlag{
 			Name:    flagExtract,
 			Aliases: []string{"x"},
@@ -50,10 +64,6 @@ func flags() []cli.Flag {
 			Usage:   "List image filesystem layers to stdout.",
 		},
 		&cli.StringFlag{
-			Name:  flagLayerPattern,
-			Usage: "regular expression to match the 'created_by' field of image layers",
-		},
-		&cli.StringFlag{
 			Name:  flagPlatform,
 			Usage: "Required when multi-architecture. Ex. linux/arm64, darwin/amd64 or windows/amd64",
 		},
@@ -62,6 +72,11 @@ func flags() []cli.Flag {
 			Aliases:  []string{"f"},
 			Required: true,
 			Usage:    "OCI reference to list or extract files from. Ex. envoyproxy/envoy:v1.18.3 or ghcr.io/homebrew/core/envoy:1.18.3-1",
+		},
+		&cli.IntFlag{
+			Name:        flagStripComponents,
+			DefaultText: "NUMBER",
+			Usage:       "Strip NUMBER leading components from file names on extraction.",
 		},
 		&cli.BoolFlag{
 			Name:    flagVerbose,
@@ -82,16 +97,27 @@ func flags() []cli.Flag {
 	}
 }
 
-func validateLayerPatternFlag(layerPattern string) (*regexp.Regexp, error) {
-	if layerPattern == "" {
+func validateCreatedByPatternFlag(createdByPattern string) (*regexp.Regexp, error) {
+	if createdByPattern == "" {
 		return nil, nil
 	}
 
-	p, err := regexp.Compile(layerPattern)
+	p, err := regexp.Compile(createdByPattern)
 	if err != nil {
-		return nil, &validationError{fmt.Sprintf("invalid [%s] flag: %s", flagLayerPattern, err)}
+		return nil, &validationError{fmt.Sprintf("invalid [%s] flag: %s", flagCreatedByPattern, err)}
 	}
 	return p, nil
+}
+
+func validateDirectoryFlag(directory string) (string, error) {
+	if directory == "" || directory == "." {
+		return os.Getwd()
+	}
+	d, err := filepath.Abs(directory)
+	if err != nil {
+		return "", &validationError{fmt.Sprintf("invalid [%s] flag: %s", flagDirectory, err)}
+	}
+	return d, nil
 }
 
 func validatePlatformFlag(platform string) (string, error) {
@@ -123,6 +149,13 @@ func validateReferenceFlag(ref string) (domain, path, tag string, err error) {
 	path = reference.Path(name)
 	tag = name.(reference.NamedTagged).Tag()
 	return
+}
+
+func validateStripComponentsFlag(stripComponents int) (int, error) {
+	if stripComponents < 0 {
+		return 0, &validationError{fmt.Sprintf("invalid [%s] flag: must be a whole number", flagStripComponents)}
+	}
+	return stripComponents, nil
 }
 
 // unBundleFlags allows tar-like syntax like `car -tvvf ghcr.io/homebrew/core/envoy:1.18.3-1`

--- a/internal/cmd/testdata/car_help.txt
+++ b/internal/cmd/testdata/car_help.txt
@@ -5,11 +5,13 @@ USAGE:
    car [global options] [arguments...]
 
 GLOBAL OPTIONS:
+   --created-by-pattern value   regular expression to match the 'created_by' field of image layers
+   --directory value, -C value  Change to [directory] before extracting files (default: .)
    --extract, -x                Extract the image filesystem layers. (default: false)
    --list, -t                   List image filesystem layers to stdout. (default: false)
-   --layer-pattern value        regular expression to match the 'created_by' field of image layers
    --platform value             Required when multi-architecture. Ex. linux/arm64, darwin/amd64 or windows/amd64
    --reference value, -f value  OCI reference to list or extract files from. Ex. envoyproxy/envoy:v1.18.3 or ghcr.io/homebrew/core/envoy:1.18.3-1
+   --strip-components value     Strip NUMBER leading components from file names on extraction. (default: NUMBER)
    --verbose, -v                Produce verbose output. In extract mode, this will list each file name as it is extracted.In list mode, this produces output similar to ls. (default: false)
    --fast-read, -q              Extract or list only the first archive entry that matches each pattern or filename operand. (default: false)
    --very-verbose, --vv         Produce very verbose output. This produces arg header for each image layer and file details similar to ls. (default: false)

--- a/internal/registry/docker/docker.go
+++ b/internal/registry/docker/docker.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net/http"
 
-	httpclient "github.com/tetratelabs/car/internal/httpclient"
+	"github.com/tetratelabs/car/internal/httpclient"
 )
 
 // bearerAuth ensures there's a valid Bearer token prior to invoking the real request

--- a/internal/registry/docker/docker_test.go
+++ b/internal/registry/docker/docker_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	httpclient "github.com/tetratelabs/car/internal/httpclient"
+	"github.com/tetratelabs/car/internal/httpclient"
 )
 
 func TestRoundTripper(t *testing.T) {

--- a/internal/registry/fake/fake.go
+++ b/internal/registry/fake/fake.go
@@ -66,12 +66,19 @@ func (f *fakeRegistry) ReadFilesystemLayer(_ context.Context, layer *internal.Fi
 	if files == nil {
 		return fmt.Errorf("layer %s not found", layer.URL)
 	}
-	for _, file := range files {
+	for i, file := range files {
 		modTime, err := time.Parse(time.RFC3339, file.modTimeRFC3339)
 		if err != nil {
 			return err
 		}
-		err = readFile(file.name, file.size, file.mode, modTime, bytes.NewReader([]byte{}))
+
+		// make a fake file with contents that differ based on the index (this is to tell apart in debugger)
+		var fakeFile = make([]byte, file.size)
+		for j := 0; j < len(fakeFile); j++ {
+			fakeFile[j] = byte(i)
+		}
+
+		err = readFile(file.name, file.size, file.mode, modTime, bytes.NewReader(fakeFile))
 		if err != nil {
 			return err
 		}
@@ -85,19 +92,19 @@ func fakeFilesystemLayers(baseURL string) []*internal.FilesystemLayer {
 		{
 			URL:       fmt.Sprintf("%s/blobs/%s", baseURL, "sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f"),
 			MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
-			Size:      26697009,
+			Size:      30,
 			CreatedBy: `/bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / `,
 		},
 		{
 			URL:       fmt.Sprintf("%s/blobs/%s", baseURL, "sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2"),
 			MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
-			Size:      2000000,
+			Size:      30,
 			CreatedBy: `ADD build/* /usr/local/bin/ # buildkit`,
 		},
 		{
 			URL:       fmt.Sprintf("%s/blobs/%s", baseURL, "sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81"),
 			MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
-			Size:      4000000,
+			Size:      40,
 			CreatedBy: `cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)`,
 		},
 	}

--- a/internal/registry/fake/fake.go
+++ b/internal/registry/fake/fake.go
@@ -107,6 +107,12 @@ func fakeFilesystemLayers(baseURL string) []*internal.FilesystemLayer {
 			Size:      40,
 			CreatedBy: `cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)`,
 		},
+		{
+			URL:       fmt.Sprintf("%s/blobs/%s", baseURL, "sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241"),
+			MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+			Size:      50,
+			CreatedBy: `ADD build/* /usr/local/sbin/ # buildkit`,
+		},
 	}
 }
 
@@ -129,5 +135,8 @@ var fakeFiles = [][]*fakeFile{
 	},
 	{
 		{"Files/ProgramData/truck/bin/truck.exe", 40, 0644 & os.ModePerm, "2021-05-12T03:53:15Z"},
+	},
+	{
+		{"usr/local/sbin/car", 50, 0755 & os.ModePerm, "2021-05-12T03:53:29Z"},
 	},
 }

--- a/internal/registry/fake/fake_test.go
+++ b/internal/registry/fake/fake_test.go
@@ -35,7 +35,7 @@ func TestNewRegistry(t *testing.T) {
 
 	require.Equal(t, "fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0", r.(*fakeRegistry).image.URL)
 	require.Equal(t, "linux/amd64", r.(*fakeRegistry).image.Platform)
-	require.Equal(t, 3, len(r.(*fakeRegistry).image.FilesystemLayers))
+	require.Equal(t, 4, len(r.(*fakeRegistry).image.FilesystemLayers))
 }
 
 func TestGetImage(t *testing.T) {

--- a/internal/registry/fake/fake_test.go
+++ b/internal/registry/fake/fake_test.go
@@ -55,7 +55,12 @@ func TestReadFilesystemLayer(t *testing.T) {
 			require.Equal(t, fakeFiles[0][i].size, size)
 			require.Equal(t, fakeFiles[0][i].mode, mode)
 			require.Equal(t, fakeFiles[0][i].modTimeRFC3339, modTime.Format(time.RFC3339))
-			require.NotNil(t, reader)
+
+			// verify the fake body exists
+			b, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, fakeFiles[0][i].size, int64(len(b)))
+
 			i++
 			return nil
 		})


### PR DESCRIPTION
This adds all the commands needed by archive-envoy. Examples below:

## Linux
```bash
$ for arch in amd64 arm64; do ./car \
  --platform linux/${arch} \
  --created-by-pattern 'ADD linux' \
  --strip-components 2 \
  -C /tmp/envoy-v1.18.3-linux-${arch} \
  -qxvvf envoyproxy/envoy:v1.18.3; done
https://index.docker.io/v2/envoyproxy/envoy/manifests/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f platform=linux/amd64 totalLayerSize: 51356424
https://index.docker.io/v2/envoyproxy/envoy/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=21729278
CreatedBy: ADD linux/amd64/build_release_stripped/* /usr/local/bin/ # buildkit
-rwxr-xr-x	64499832	May 12 03:53:29	usr/local/bin/envoy
https://index.docker.io/v2/envoyproxy/envoy/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=3500
CreatedBy: ADD linux/amd64/build_release/su-exec /usr/local/bin/ # buildkit
-r-xr-xr-x	12560	May 12 03:53:15	usr/local/bin/su-exec
https://index.docker.io/v2/envoyproxy/envoy/manifests/sha256:f1cb90d4df0521842fe5f5c01a00032c76ba1743e1b2477589103373af06707c platform=linux/arm64 totalLayerSize: 46323470
https://index.docker.io/v2/envoyproxy/envoy/blobs/sha256:97c59091ec632eb43a1f8ae51f48200b97a580b9fbf0c591ad5cccd12d2bd573 size=19994790
CreatedBy: ADD linux/arm64/build_release_stripped/* /usr/local/bin/ # buildkit
-rwxr-xr-x	60254080	May 12 04:20:32	usr/local/bin/envoy
https://index.docker.io/v2/envoyproxy/envoy/blobs/sha256:af66acd072fe6384d76fe0f86ccf256a9a6ae9c6cb8b2b38c9ea4241cb92aeca size=3888
CreatedBy: ADD linux/arm64/build_release/su-exec /usr/local/bin/ # buildkit
-r-xr-xr-x	70408	May 12 04:20:30	usr/local/bin/su-exec

$ find /tmp/envoy-v1.18.3-linux-*
/tmp/envoy-v1.18.3-linux-amd64
/tmp/envoy-v1.18.3-linux-amd64/bin
/tmp/envoy-v1.18.3-linux-amd64/bin/su-exec
/tmp/envoy-v1.18.3-linux-amd64/bin/envoy
/tmp/envoy-v1.18.3-linux-arm64
/tmp/envoy-v1.18.3-linux-arm64/bin
/tmp/envoy-v1.18.3-linux-arm64/bin/su-exec
/tmp/envoy-v1.18.3-linux-arm64/bin/envoy
```

## Linux Debug
```bash
$ for arch in amd64 arm64; do ./car \
  --platform linux/${arch} \
  --created-by-pattern 'ADD linux' \
  --strip-components 2 \
  -C /tmp/envoy-v1.18.3_debug-linux-${arch} \
  -qxvvf envoyproxy/envoy-debug:v1.18.3; done
https://index.docker.io/v2/envoyproxy/envoy-debug/manifests/sha256:a4a922679a09afd363b5890a87ea32adb9a4a892b689d92d26408f54156ce349 platform=linux/amd64 totalLayerSize: 709317608
https://index.docker.io/v2/envoyproxy/envoy-debug/blobs/sha256:624ea4e643a18e428708b68e6f2e0daed41987a474ac811f8be4171f9e1edc08 size=679693968
CreatedBy: ADD linux/amd64/build_release/* /usr/local/bin/ # buildkit
-r-xr-xr-x	542054344	May 12 03:53:15	usr/local/bin/envoy
-r-xr-xr-x	1584151632	May 12 03:53:29	usr/local/bin/envoy.dwp
-r-xr-xr-x	12560	May 12 03:53:15	usr/local/bin/su-exec
https://index.docker.io/v2/envoyproxy/envoy-debug/manifests/sha256:7cd5d4f901232f98a322d6e5398ae40b5f2ce1b0c9bfa664368b249519f6abbb platform=linux/arm64 totalLayerSize: 699203134
https://index.docker.io/v2/envoyproxy/envoy-debug/blobs/sha256:d85577ad6cd5119692c2c2757442a6f9ae59d97a67f73a37eff267ff9562972b size=672878336
CreatedBy: ADD linux/arm64/build_release/* /usr/local/bin/ # buildkit
-r-xr-xr-x	577252704	May 12 04:20:30	usr/local/bin/envoy
-r-xr-xr-x	1569550568	May 12 04:20:32	usr/local/bin/envoy.dwp
-r-xr-xr-x	70408	May 12 04:20:30	usr/local/bin/su-exec

$ find /tmp/envoy-v1.18.3_debug-linux*
/tmp/envoy-v1.18.3_debug-linux-amd64
/tmp/envoy-v1.18.3_debug-linux-amd64/bin
/tmp/envoy-v1.18.3_debug-linux-amd64/bin/su-exec
/tmp/envoy-v1.18.3_debug-linux-amd64/bin/envoy
/tmp/envoy-v1.18.3_debug-linux-amd64/bin/envoy.dwp
/tmp/envoy-v1.18.3_debug-linux-arm64
/tmp/envoy-v1.18.3_debug-linux-arm64/bin
/tmp/envoy-v1.18.3_debug-linux-arm64/bin/su-exec
/tmp/envoy-v1.18.3_debug-linux-arm64/bin/envoy
/tmp/envoy-v1.18.3_debug-linux-arm64/bin/envoy.dwp
```

# MacOS
```
$ ./car \
  --strip-components 2 \
  -C /tmp/envoy-v1.18.3-darwin-amd64 \
  -qxvvf ghcr.io/homebrew/core/envoy:1.18.3-1 envoy/1.18.3/bin/envoy
https://ghcr.io/v2/homebrew/core/envoy/manifests/sha256:03efb0078d32e24f3730afb13fc58b635bd4e9c6d5ab32b90af3922efc7f8672 platform=darwin/amd64 totalLayerSize: 29405739
https://ghcr.io/v2/homebrew/core/envoy/blobs/sha256:d03fb86b48336c8d3c0f3711cfc3df3557f9fb33c966ceb1caecae1653935e90 size=29405739
CreatedBy: 
-r-xr-xr-x	124804608	May 12 02:04:24	envoy/1.18.3/bin/envoy

$ find /tmp/envoy-v1.18.3-darwin-amd64
/tmp/envoy-v1.18.3-darwin-amd64
/tmp/envoy-v1.18.3-darwin-amd64/bin
/tmp/envoy-v1.18.3-darwin-amd64/bin/envoy
```

## Windows
```bash
$ ./car \
  --created-by-pattern ADD \
  --strip-components 3 \
  -C /tmp/envoy-v1.18.3-windows-amd64/bin \
  -qxvvf envoyproxy/envoy-windows:v1.18.3 'Files/Program Files/envoy/envoy.exe'
https://index.docker.io/v2/envoyproxy/envoy-windows/manifests/v1.18.3 platform=windows/amd64 totalLayerSize: 13634055
https://index.docker.io/v2/envoyproxy/envoy-windows/blobs/sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4 size=12217107
CreatedBy: cmd /S /C #(nop) ADD file:61df7bfb8255c0673d4ed25f961df5121141ee800202081e549fc36828624577 in C:\Program Files\envoy\ 
----------	33538560	May 12 06:32:28	Files/Program Files/envoy/envoy.exe

$ find /tmp/envoy-v1.18.3-windows-amd64
/tmp/envoy-v1.18.3-windows-amd64
/tmp/envoy-v1.18.3-windows-amd64/bin
/tmp/envoy-v1.18.3-windows-amd64/bin/envoy.exe
```
