### PR TITLE
Defaults windows to read perms so that unix can read files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ $ ./car -tvvf chocolateyfest/chocolatey:latest
 https://index.docker.io/v2/chocolateyfest/chocolatey/manifests/latest platform=windows/amd64 totalLayerSize: 24102006
 https://index.docker.io/v2/chocolateyfest/chocolatey/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=24102006
 CreatedBy: cmd /S /C powershell iex(iwr -useb https://chocolatey.org/install.ps1)
--r--r--r--	44245	May  5 02:09:14	Files/ProgramData/chocolatey/CREDITS.txt
--r--r--r--	670	May  5 02:09:14	Files/ProgramData/chocolatey/LICENSE.txt
--r--r--r--	2283	May  5 02:09:14	Files/ProgramData/chocolatey/bin/RefreshEnv.cmd
+-rw-r--r--	44245	May  5 02:09:14	Files/ProgramData/chocolatey/CREDITS.txt
+-rw-r--r--	670	May  5 02:09:14	Files/ProgramData/chocolatey/LICENSE.txt
+-rw-r--r--	2283	May  5 02:09:14	Files/ProgramData/chocolatey/bin/RefreshEnv.cmd
 --snip--
 
 # try a multi-platform image

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ $ ./car -tvvf chocolateyfest/chocolatey:latest
 https://index.docker.io/v2/chocolateyfest/chocolatey/manifests/latest platform=windows/amd64 totalLayerSize: 24102006
 https://index.docker.io/v2/chocolateyfest/chocolatey/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=24102006
 CreatedBy: cmd /S /C powershell iex(iwr -useb https://chocolatey.org/install.ps1)
-----------	44245	May  5 02:09:14	Files/ProgramData/chocolatey/CREDITS.txt
-----------	670	May  5 02:09:14	Files/ProgramData/chocolatey/LICENSE.txt
-----------	2283	May  5 02:09:14	Files/ProgramData/chocolatey/bin/RefreshEnv.cmd
+-r--r--r--	44245	May  5 02:09:14	Files/ProgramData/chocolatey/CREDITS.txt
+-r--r--r--	670	May  5 02:09:14	Files/ProgramData/chocolatey/LICENSE.txt
+-r--r--r--	2283	May  5 02:09:14	Files/ProgramData/chocolatey/bin/RefreshEnv.cmd
 --snip--
 
 # try a multi-platform image

--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -61,12 +61,12 @@ func (c *car) List(ctx context.Context, tag, platform string) error {
 	}
 
 	pm := patternmatcher.New(c.filePatterns, c.fastRead)
-	rf := func(name string, size, mode int64, modTime time.Time, _ io.Reader) error {
+	rf := func(name string, size int64, mode os.FileMode, modTime time.Time, _ io.Reader) error {
 		if !pm.MatchesPattern(name) {
 			return nil
 		}
 		if c.verbose {
-			fmt.Fprintf(c.out, "%s\t%d\t%s\t%s\n", fs.FileMode(mode), size, modTime.Format(time.Stamp), name)
+			fmt.Fprintf(c.out, "%s\t%d\t%s\t%s\n", mode, size, modTime.Format(time.Stamp), name)
 		} else {
 			fmt.Fprintln(c.out, name)
 		}

--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -100,7 +100,7 @@ CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 			expectedOut: `-rw-r-----	10	Jun  7 06:28:15	bin/apple.txt
 -rwxr-xr-x	20	Apr 16 22:53:09	usr/local/bin/boat
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
--r--r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
+-rw-r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 		{
@@ -116,7 +116,7 @@ CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
 fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=4000000
 CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
--r--r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
+-rw-r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 	}

--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 	}{
 		{
 			name: "normal",
-			expectedOut: `bin/bash
+			expectedOut: `bin/apple.txt
 usr/local/bin/boat
 usr/local/bin/car
 Files/ProgramData/truck/bin/truck.exe
@@ -46,8 +46,8 @@ Files/ProgramData/truck/bin/truck.exe
 		},
 		{
 			name:     "all patterns match",
-			patterns: []string{"bin/bash", "usr/local/bin/*", "Files/ProgramData/truck/bin/*"},
-			expectedOut: `bin/bash
+			patterns: []string{"bin/apple.txt", "usr/local/bin/*", "Files/ProgramData/truck/bin/*"},
+			expectedOut: `bin/apple.txt
 usr/local/bin/boat
 usr/local/bin/car
 Files/ProgramData/truck/bin/truck.exe
@@ -85,7 +85,7 @@ fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625
 CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / 
 fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=2000000
 CreatedBy: ADD build/* /usr/local/bin/ # buildkit
--rwxr-xr-x	4000000	May 12 03:53:29	usr/local/bin/car
+-rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
 `,
 		},
 		{
@@ -97,10 +97,10 @@ CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 		{
 			name:    "verbose",
 			verbose: true,
-			expectedOut: `-rwxr-xr-x	1113504	Jun  7 06:28:15	bin/bash
--rwxr-xr-x	1000000	Apr 16 22:53:09	usr/local/bin/boat
--rwxr-xr-x	4000000	May 12 03:53:29	usr/local/bin/car
--rwxr-xr-x	8000000	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
+			expectedOut: `-rw-r-----	10	Jun  7 06:28:15	bin/apple.txt
+-rwxr-xr-x	20	Apr 16 22:53:09	usr/local/bin/boat
+-rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
+-r--r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 		{
@@ -109,14 +109,14 @@ CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 32697009
 fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=26697009
 CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / 
--rwxr-xr-x	1113504	Jun  7 06:28:15	bin/bash
--rwxr-xr-x	1000000	Apr 16 22:53:09	usr/local/bin/boat
+-rw-r-----	10	Jun  7 06:28:15	bin/apple.txt
+-rwxr-xr-x	20	Apr 16 22:53:09	usr/local/bin/boat
 fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=2000000
 CreatedBy: ADD build/* /usr/local/bin/ # buildkit
--rwxr-xr-x	4000000	May 12 03:53:29	usr/local/bin/car
+-rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
 fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=4000000
 CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
--rwxr-xr-x	8000000	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
+-r--r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
 `,
 		},
 	}

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -67,7 +67,7 @@ show usage with: car help
 		{
 			name: "list",
 			args: []string{"car", "-tf", "tetratelabs/car:v1.0"},
-			expectedStdout: `bin/bash
+			expectedStdout: `bin/apple.txt
 usr/local/bin/boat
 usr/local/bin/car
 Files/ProgramData/truck/bin/truck.exe

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"time"
 )
 
@@ -46,7 +47,7 @@ type Registry interface {
 //
 // Arguments correspond with tar.Header fields and are unaltered when this is backed by a tar.
 // The reader argument optionally reads from the current file until io.EOF. Use the size argument to be more precise.
-type ReadFile func(name string, size int64, mode int64, modTime time.Time, reader io.Reader) error
+type ReadFile func(name string, size int64, mode os.FileMode, modTime time.Time, reader io.Reader) error
 
 // Image represents filesystem layers that make up an image on a specific Platform, parsed from the OCI manifest and
 // configuration.

--- a/internal/registry/fake/fake.go
+++ b/internal/registry/fake/fake.go
@@ -121,6 +121,6 @@ var fakeFiles = [][]*fakeFile{
 		{"usr/local/bin/car", 30, 0755 & os.ModePerm, "2021-05-12T03:53:29Z"},
 	},
 	{
-		{"Files/ProgramData/truck/bin/truck.exe", 40, 0444 & os.ModePerm, "2021-05-12T03:53:15Z"},
+		{"Files/ProgramData/truck/bin/truck.exe", 40, 0644 & os.ModePerm, "2021-05-12T03:53:15Z"},
 	},
 }

--- a/internal/registry/fake/fake.go
+++ b/internal/registry/fake/fake.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/tetratelabs/car/internal"
@@ -105,7 +106,7 @@ func fakeFilesystemLayers(baseURL string) []*internal.FilesystemLayer {
 type fakeFile struct {
 	name           string
 	size           int64
-	mode           int64
+	mode           os.FileMode
 	modTimeRFC3339 string
 }
 
@@ -113,13 +114,13 @@ type fakeFile struct {
 // The fake data intentionally overlaps on "usr/local" for testing. Even if weird, it adds windows paths.
 var fakeFiles = [][]*fakeFile{
 	{
-		{"bin/bash", 1113504, 0755, "2020-06-07T06:28:15Z"},
-		{"usr/local/bin/boat", 1000000, 0755, "2021-04-16T22:53:09Z"},
+		{"bin/apple.txt", 10, 0640 & os.ModePerm, "2020-06-07T06:28:15Z"},
+		{"usr/local/bin/boat", 20, 0755 & os.ModePerm, "2021-04-16T22:53:09Z"},
 	},
 	{
-		{"usr/local/bin/car", 4000000, 0755, "2021-05-12T03:53:29Z"},
+		{"usr/local/bin/car", 30, 0755 & os.ModePerm, "2021-05-12T03:53:29Z"},
 	},
 	{
-		{"Files/ProgramData/truck/bin/truck.exe", 8000000, 0755, "2021-05-12T03:53:15Z"},
+		{"Files/ProgramData/truck/bin/truck.exe", 40, 0444 & os.ModePerm, "2021-05-12T03:53:15Z"},
 	},
 }

--- a/internal/registry/fake/fake_test.go
+++ b/internal/registry/fake/fake_test.go
@@ -17,6 +17,7 @@ package fake
 import (
 	"context"
 	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -49,7 +50,7 @@ func TestReadFilesystemLayer(t *testing.T) {
 	layer := r.(*fakeRegistry).image.FilesystemLayers[0]
 	i := 0
 	err := r.ReadFilesystemLayer(context.Background(), layer,
-		func(name string, size int64, mode int64, modTime time.Time, reader io.Reader) error {
+		func(name string, size int64, mode os.FileMode, modTime time.Time, reader io.Reader) error {
 			require.Equal(t, fakeFiles[0][i].name, name)
 			require.Equal(t, fakeFiles[0][i].size, size)
 			require.Equal(t, fakeFiles[0][i].mode, mode)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -246,7 +246,11 @@ func (r *registry) ReadFilesystemLayer(ctx context.Context, layer *internal.File
 		if strings.Contains(th.Name, ".wh.") {
 			continue
 		}
-		if err := readFile(th.Name, th.Size, th.Mode, th.ModTime, tr); err != nil {
+		mode := th.FileInfo().Mode()
+		if mode.Perm() == 0 {
+			mode = 0444 // Windows doesn't need the execute bit, but without read, we can't extract on Linux or Darwin!
+		}
+		if err := readFile(th.Name, th.Size, mode, th.ModTime, tr); err != nil {
 			return fmt.Errorf("error calling readFile on %s: %w", th.Name, err)
 		}
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	pathutil "path"
 	"sort"
 	"strings"
@@ -248,7 +249,8 @@ func (r *registry) ReadFilesystemLayer(ctx context.Context, layer *internal.File
 		}
 		mode := th.FileInfo().Mode()
 		if mode.Perm() == 0 {
-			mode = 0444 // Windows doesn't need the execute bit, but without read, we can't extract on Linux or Darwin!
+			// Windows doesn't need the execute bit, this makes `car` usable on darwin and linux.
+			mode = 0644 & os.ModePerm
 		}
 		if err := readFile(th.Name, th.Size, mode, th.ModTime, tr); err != nil {
 			return fmt.Errorf("error calling readFile on %s: %w", th.Name, err)


### PR DESCRIPTION
Archival isn't used for exact owner and perms, it is optimizing for usability.
Without read perms, this is unusable. This defaults windows files to read so
that they are extractable on another platform. Note: windows doesn't use
the execute bit, so that's not added here.