### PR TITLE
Fixes coverage and updates to GitHub action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# See https://editorconfig.org/#file-format-details
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Improves experience of commands like `make format` on Windows
+* text=auto eol=lf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @codefromthecrypt @mathetake

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache Go"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           # go.mod for go release version, go.sum for modules used, and Tools.mk for 'go run' tools
@@ -56,6 +56,7 @@ jobs:
 
       - name: "Upload coverage report"  # only on master push and only once (not per OS)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && runner.os == 'Linux'
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:  # fetch all history for all tags and branches (needed for changelog)
           fetch-depth: 0
 

--- a/.licenserignore
+++ b/.licenserignore
@@ -1,4 +1,5 @@
 .editorconfig
+codecov.yml
 
 /LICENSE
 

--- a/Tools.mk
+++ b/Tools.mk
@@ -1,6 +1,6 @@
 # Copyright 2021 Tetrate
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 goimports     := golang.org/x/tools/cmd/goimports@v0.1.10
 licenser      := github.com/liamawhite/licenser@v0.6.0

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# Codecov for main is visible here https://app.codecov.io/gh/tetratelabs/car
+
+# We use codecov only as a UI, so we disable PR comments.
+# See https://docs.codecov.com/docs/pull-request-comments
+comment: false

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,12 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/urfave/cli/v2 v2.6.0
+	github.com/urfave/cli/v2 v2.8.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,10 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/urfave/cli/v2 v2.6.0 h1:yj2Drkflh8X/zUrkWlWlUjZYHyWN7WMmpVxyxXIUyv8=
-github.com/urfave/cli/v2 v2.6.0/go.mod h1:oDzoM7pVwz6wHn5ogWgFUU1s4VJayeQS+aEZDqXIEJs=
+github.com/urfave/cli/v2 v2.8.1 h1:CGuYNZF9IKZY/rfBe3lJpccSoIY1ytfvmgQT90cNOl4=
+github.com/urfave/cli/v2 v2.8.1/go.mod h1:Z41J9TPoffeoqP0Iza0YbAhGvymRdZAd2uPmZ5JxRdY=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/internal/cmd/testdata/.editorconfig
+++ b/internal/cmd/testdata/.editorconfig
@@ -1,0 +1,7 @@
+# See https://editorconfig.org/#file-format-details
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false

--- a/internal/cmd/testdata/.editorconfig
+++ b/internal/cmd/testdata/.editorconfig
@@ -1,7 +1,4 @@
-# See https://editorconfig.org/#file-format-details
-
-[*]
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
+# see https://github.com/mvdan/sh#shfmt
+[*.{txt,md}]
+insert_final_newline     = false
 trim_trailing_whitespace = false

--- a/internal/cmd/testdata/car_help.txt
+++ b/internal/cmd/testdata/car_help.txt
@@ -8,10 +8,11 @@ GLOBAL OPTIONS:
    --created-by-pattern value   regular expression to match the 'created_by' field of image layers
    --directory value, -C value  Change to [directory] before extracting files (default: .)
    --extract, -x                Extract the image filesystem layers. (default: false)
+   --fast-read, -q              Extract or list only the first archive entry that matches each pattern or filename operand. (default: false)
    --list, -t                   List image filesystem layers to stdout. (default: false)
    --platform value             Required when multi-architecture. Ex. linux/arm64, darwin/amd64 or windows/amd64
    --reference value, -f value  OCI reference to list or extract files from. Ex. envoyproxy/envoy:v1.18.3 or ghcr.io/homebrew/core/envoy:1.18.3-1
    --strip-components value     Strip NUMBER leading components from file names on extraction. (default: NUMBER)
    --verbose, -v                Produce verbose output. In extract mode, this will list each file name as it is extracted.In list mode, this produces output similar to ls. (default: false)
-   --fast-read, -q              Extract or list only the first archive entry that matches each pattern or filename operand. (default: false)
    --very-verbose, --vv         Produce very verbose output. This produces arg header for each image layer and file details similar to ls. (default: false)
+   


### PR DESCRIPTION
The coverage target broke in a way already fixed in func-e. This fixes
that. As there's no significant architecture-specific code, this moves
to the GitHub action for uploading to codecov.

This also bumps versions to be consistent.

Thanks to @anuraaga for noticing the uploader script is deprecated.
