### PR TITLE
Removes secret from codecov upload

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -58,5 +58,4 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && runner.os == 'Linux'
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt


### PR DESCRIPTION
post merge, if this works I'll do it to func-e and delete the repo secret.