### PR TITLE
removes docker/distribution dependency

### DIFF
--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -220,7 +220,7 @@ func (r *referenceValue) Set(val string) error {
 	// be a tagged image.
 	indexColon := strings.LastIndexByte(val, byte(':'))
 	indexSlash := strings.IndexByte(val, byte('/'))
-	if indexColon == -1 || indexSlash > indexColon {
+	if indexColon == -1 || indexSlash > indexColon /* e.g. host:80/image */ {
 		return errors.New("expected tagged reference")
 	}
 

--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -25,10 +25,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/docker/distribution/reference"
-
 	"github.com/tetratelabs/car/internal"
-	carutil "github.com/tetratelabs/car/internal/car"
+	"github.com/tetratelabs/car/internal/car"
 	"github.com/tetratelabs/car/internal/registry"
 )
 
@@ -132,14 +130,14 @@ func doMain(ctx context.Context, newRegistry internal.NewRegistry, stdout, stder
 
 	if err := flag.Parse(unBundleFlags(os.Args[1:])); err != nil {
 		exit(1) // usage would have already been printed
-	} else if help {
+	} else if help || len(os.Args) == 1 {
 		flag.Usage()
 		exit(0)
 	} else {
 		domain, path, tag := reference.Get()
 		createdByPattern := createdByPattern.p
 
-		car := carutil.New(
+		car := car.New(
 			newRegistry(ctx, domain, path),
 			stdout,
 			createdByPattern,
@@ -205,36 +203,56 @@ func unBundleFlag(argIn, flag string, args *[]string) string {
 	}
 }
 
+// referenceValue is a simplified parser of OCI references that handle Docker
+// familiar images. This is not strict, so a bad URL will result in a HTTP
+// error.
 type referenceValue struct {
-	nt reference.NamedTagged
+	domain, path, tag string
 }
 
 // Set implements flag.Value
 func (r *referenceValue) Set(val string) error {
-	name, err := reference.ParseNormalizedNamed(val)
-	if err != nil {
-		return err
+	if val == "" {
+		return errors.New("invalid reference format")
 	}
-	if nt, ok := name.(reference.NamedTagged); !ok {
+
+	// First, check to see if there's at least one colon. If not, this cannot
+	// be a tagged image.
+	indexColon := strings.LastIndexByte(val, byte(':'))
+	indexSlash := strings.IndexByte(val, byte('/'))
+	if indexColon == -1 || indexSlash > indexColon {
 		return errors.New("expected tagged reference")
-	} else {
-		*r = referenceValue{nt: nt}
 	}
+
+	r.tag = val[indexColon+1:]
+	remaining := val[0:indexColon]
+
+	// See if this is a familiar official docker image. e.g. "alpine:3.14.0"
+	if indexSlash == -1 {
+		r.domain = "docker.io"
+		r.path = "library/" + remaining
+		return nil
+	}
+
+	// See if this is an official docker image. e.g. "envoyproxy/envoy:v1.18.3"
+	if strings.LastIndexByte(val, byte('/')) == indexSlash {
+		r.domain = "docker.io"
+		r.path = remaining
+		return nil
+	}
+
+	// Otherwise, the part leading to the first slash is the domain.
+	r.domain = remaining[0:indexSlash]
+	r.path = remaining[indexSlash+1:]
 	return nil
 }
 
 func (r *referenceValue) Get() (domain, path, tag string) {
-	domain = reference.Domain(r.nt)
-	path = reference.Path(r.nt)
-	tag = r.nt.Tag()
-	return
+	return r.domain, r.path, r.tag
 }
 
 func (r *referenceValue) String() string {
-	if r.nt == nil {
-		return ""
-	}
-	return r.nt.String()
+	return r.domain
 }
 
 type platformValue string

--- a/cmd/car/flags_test.go
+++ b/cmd/car/flags_test.go
@@ -228,6 +228,16 @@ func Test_referenceValue(t *testing.T) {
 			expectedTag:    "latest",
 		},
 		{
+			name:        "empty",
+			reference:   "",
+			expectedErr: "invalid reference format",
+		},
+		{
+			name:        "docker familiar, but no tag",
+			reference:   "foo/bar",
+			expectedErr: "expected tagged reference",
+		},
+		{
 			name:        "missing tag",
 			reference:   "registry:5000/tetratelabs/car",
 			expectedErr: "expected tagged reference",

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,10 @@ module github.com/tetratelabs/car
 
 go 1.19
 
-require (
-	github.com/docker/distribution v2.8.1+incompatible
-	github.com/stretchr/testify v1.8.2
-)
+require github.com/stretchr/testify v1.8.2
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
-github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This removes the docker/distribution dependency which has several indirect dependencies and hasn't released a version in a long time.

Instead, this does basic inline parsing, passing the existing tests.

Next step is modifying to work with well-known wasm OCI styles, then exposing the API so that wazero users can intergrate with it.