### PR TITLE
Moves path/repo out of the registry

### DIFF
--- a/cmd/car/car.go
+++ b/cmd/car/car.go
@@ -137,8 +137,13 @@ func doMain(ctx context.Context, newRegistry internal.NewRegistry, stdout, stder
 		domain, path, tag := reference.Get()
 		createdByPattern := createdByPattern.p
 
+		r, err := newRegistry(ctx, domain)
+		if err != nil {
+			fmt.Fprintln(stderr, "error:", err)
+			exit(1)
+		}
 		car := car.New(
-			newRegistry(ctx, domain, path),
+			r,
 			stdout,
 			createdByPattern,
 			flag.Args(),
@@ -152,9 +157,9 @@ func doMain(ctx context.Context, newRegistry internal.NewRegistry, stdout, stder
 				fmt.Fprintf(stderr, "you cannot combine flags [%s] and [%s]\n%s", flagList, flagExtract, usage)
 				exit(1)
 			}
-			err = car.List(ctx, tag, string(platform))
+			err = car.List(ctx, path, tag, string(platform))
 		} else if extract {
-			err = car.Extract(ctx, tag, string(platform), string(directory), int(stripComponents))
+			err = car.Extract(ctx, path, tag, string(platform), string(directory), int(stripComponents))
 		}
 		if err != nil {
 			fmt.Fprintln(stderr, "error:", err)

--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -85,9 +85,9 @@ usr/local/bin/car
 			veryVerbose: true,
 			patterns:    []string{"usr/local/bin/car"},
 			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / 
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
+fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
+CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
+fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
 CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
 `,
@@ -113,17 +113,17 @@ usr/local/sbin/car
 			name:        "veryVerbose",
 			veryVerbose: true,
 			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / 
+fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
+CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
 -rw-r-----	10	Jun  7 06:28:15	bin/apple.txt
 -rwxr-xr-x	20	Apr 16 22:53:09	usr/local/bin/boat
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
+fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
 CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=40
+fake://ghcr.io/v2/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=40
 CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
 -rw-r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=50
+fake://ghcr.io/v2/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=50
 CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 -rwxr-xr-x	50	May 12 03:53:29	usr/local/sbin/car
 `,
@@ -135,10 +135,12 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			stdout := new(bytes.Buffer)
+			var stdout bytes.Buffer
+			r, err := fake.NewRegistry(ctx, "ghcr.io")
+			require.NoError(t, err)
 			c := New(
-				fake.NewRegistry(ctx, "ghcr.io", "tetratelabs/car"),
-				stdout,
+				r,
+				&stdout,
 				tc.createdByPattern,
 				tc.patterns,
 				tc.fastRead,
@@ -146,7 +148,7 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 				tc.veryVerbose,
 			)
 
-			err := c.List(ctx, tag, platform)
+			err = c.List(ctx, "tetratelabs/car", tag, platform)
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 				require.Equal(t, tc.expectedOut, stdout.String())
@@ -226,9 +228,9 @@ func TestExtract(t *testing.T) {
 				"usr/local/bin/car": 30,
 			},
 			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / 
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
+fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
+CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
+fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
 CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
 `,
@@ -280,17 +282,17 @@ usr/local/sbin/car
 			veryVerbose:         true,
 			expectedFileToSizes: allFilesToSizes,
 			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / 
+fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
+CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
 -rw-r-----	10	Jun  7 06:28:15	bin/apple.txt
 -rwxr-xr-x	20	Apr 16 22:53:09	usr/local/bin/boat
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
+fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
 CreatedBy: ADD build/* /usr/local/bin/ # buildkit
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=40
+fake://ghcr.io/v2/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=40
 CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
 -rw-r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
-fake://ghcr.io/v2/tetratelabs/car/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=50
+fake://ghcr.io/v2/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=50
 CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 -rwxr-xr-x	50	May 12 03:53:29	usr/local/sbin/car
 `,
@@ -302,10 +304,12 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			stdout := new(bytes.Buffer)
+			var stdout bytes.Buffer
+			r, err := fake.NewRegistry(ctx, "ghcr.io")
+			require.NoError(t, err)
 			c := New(
-				fake.NewRegistry(ctx, "ghcr.io", "tetratelabs/car"),
-				stdout,
+				r,
+				&stdout,
 				tc.createdByPattern,
 				tc.patterns,
 				tc.fastRead,
@@ -317,7 +321,7 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 			require.NoError(t, err, `ioutil.TempDir("", "") erred`)
 			defer os.RemoveAll(directory) //nolint
 
-			err = c.Extract(ctx, tag, platform, directory, tc.stripComponents)
+			err = c.Extract(ctx, "tetratelabs/car", tag, platform, directory, tc.stripComponents)
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 				require.Equal(t, tc.expectedOut, stdout.String())

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -93,16 +93,6 @@ type Image struct {
 	// typically 'runtime.GOOS/runtime.GOARCH'. e.g. "darwin/amd64"
 	Platform string
 
-	// Env are the default environment variables the runtime should assign.
-	Env []string
-
-	// Entrypoint is the beginning of the ARGV array. Conventionally, when
-	// absent this is interpreted as []string{"/bin/sh", "-c"}.
-	Entrypoint []string
-
-	// Cmd is appended after Entrypoint to complete the ARGV array.
-	Cmd []string
-
 	// FilesystemLayers are the filesystem layers of this image.
 	FilesystemLayers []*FilesystemLayer
 }

--- a/internal/registry/docker/docker_test.go
+++ b/internal/registry/docker/docker_test.go
@@ -36,7 +36,7 @@ func TestRoundTripper(t *testing.T) {
 	}
 	expectedTagList := tagList{"envoy", []string{"v1.18.1", "v1.18.2"}}
 
-	url, err := urlpkg.Parse("https://docker.io/v2/envoyproxy/envoy/tags/list?n=100")
+	url, err := urlpkg.Parse("https://docker.io/v2/envoyproxy/envoy/manifests/list?n=100")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -47,12 +47,12 @@ func TestRoundTripper(t *testing.T) {
 	}{
 		{
 			name:   "new",
-			docker: NewRoundTripper("envoyproxy/envoy"),
+			docker: NewRoundTripper(),
 			real: &mock{t, 0, []string{`GET /token?service=registry.docker.io&scope=repository:envoyproxy/envoy:pull HTTP/1.1
 Host: auth.docker.io
 Accept: application/json
 
-`, `GET /v2/envoyproxy/envoy/tags/list?n=100 HTTP/1.1
+`, `GET /v2/envoyproxy/envoy/manifests/list?n=100 HTTP/1.1
 Host: docker.io
 Authorization: Bearer a
 
@@ -60,8 +60,8 @@ Authorization: Bearer a
 		},
 		{
 			name:   "valid",
-			docker: &bearerAuth{"envoyproxy/envoy", "a"},
-			real: &mock{t, 0, []string{`GET /v2/envoyproxy/envoy/tags/list?n=100 HTTP/1.1
+			docker: &bearerAuth{"a"},
+			real: &mock{t, 0, []string{`GET /v2/envoyproxy/envoy/manifests/list?n=100 HTTP/1.1
 Host: docker.io
 Authorization: Bearer a
 
@@ -70,7 +70,7 @@ Authorization: Bearer a
 		{
 			name:        "error",
 			expectedErr: `received 401 status code from "https://auth.docker.io/token?service=registry.docker.io&scope=repository:envoyproxy/envoy:pull"`,
-			docker:      &bearerAuth{"envoyproxy/envoy", ""},
+			docker:      &bearerAuth{""},
 			real:        &errMock{},
 		},
 	}


### PR DESCRIPTION
This moves the path/repo argument out of the initialization of the repository. This aligns with most docker tools which login to a host, not a host/repo.

The motivation is to allow auth configuration via middleware when used as a library, and these won't know the repos used at config time. So, this shows it can be done.