### PR TITLE
Parses Env, Entrypoint and Cmd

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,6 +127,16 @@ type Image interface {
 	// typically 'runtime.GOOS/runtime.GOARCH'. e.g. "darwin/amd64"
 	Platform() string
 
+	// Env are the default environment variables the runtime should assign.
+	Env() []string
+
+	// Entrypoint is the beginning of the ARGV array. Conventionally, when
+	// absent this is interpreted as []string{"/bin/sh", "-c"}.
+	Entrypoint() []string
+
+	// Cmd is appended after Entrypoint to complete the ARGV array.
+	Cmd() []string
+
 	// FilesystemLayerCount is the count of layers, used to loop.
 	FilesystemLayerCount() int
 

--- a/internal/registry/fake/fake.go
+++ b/internal/registry/fake/fake.go
@@ -37,6 +37,21 @@ func (i image) Platform() string {
 	return i.platform
 }
 
+// Env implements the same method as documented on api.Image
+func (i image) Env() (env []string) {
+	return
+}
+
+// Entrypoint implements the same method as documented on api.Image
+func (i image) Entrypoint() (entrypoint []string) {
+	return
+}
+
+// Cmd implements the same method as documented on api.Image
+func (i image) Cmd() (cmd []string) {
+	return
+}
+
 // FilesystemLayerCount implements the same method as documented on api.Image
 func (i image) FilesystemLayerCount() int {
 	return len(fakeFilesystemLayers)

--- a/internal/registry/json.go
+++ b/internal/registry/json.go
@@ -46,9 +46,16 @@ const (
 // See https://github.com/opencontainers/image-spec/blob/master/schema/config-schema.json
 type imageConfigV1 struct {
 	Architecture string      `json:"architecture"`
+	Config       configV1    `json:"config,omitempty"`
 	OS           string      `json:"os"`
 	OSVersion    string      `json:"os.version,omitempty"`
 	History      []historyV1 `json:"history,omitempty"`
+}
+
+type configV1 struct {
+	Env        []string `json:"Env"`
+	Entrypoint []string `json:"Entrypoint"`
+	Cmd        []string `json:"Cmd"`
 }
 
 type historyV1 struct {
@@ -125,6 +132,9 @@ func newImage(baseURL string, manifest *imageManifestV1, config *imageConfigV1) 
 	return image{
 		url:              manifest.URL,
 		platform:         path.Join(config.OS, config.Architecture),
+		env:              config.Config.Env,
+		entrypoint:       config.Config.Entrypoint,
+		cmd:              config.Config.Cmd,
 		filesystemLayers: layers,
 	}
 }

--- a/internal/registry/json_test.go
+++ b/internal/registry/json_test.go
@@ -118,6 +118,11 @@ func TestImageConfigV1_LinuxAmd64(t *testing.T) {
 		Architecture: "amd64",
 		OS:           "linux",
 		OSVersion:    "",
+		Config: configV1{
+			Env:        []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "DEBIAN_FRONTEND=noninteractive"},
+			Entrypoint: []string{"/docker-entrypoint.sh"},
+			Cmd:        []string{"envoy", "-c", "/etc/envoy/envoy.yaml"},
+		},
 		History: []historyV1{
 			{`/bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / `, false},
 			{`/bin/sh -c set -xe 		&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d 	&& echo 'exit 101' >> /usr/sbin/policy-rc.d 	&& chmod +x /usr/sbin/policy-rc.d 		&& dpkg-divert --local --rename --add /sbin/initctl 	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl 	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl 		&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup 		&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean 		&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages 		&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes 		&& echo 'Apt::AutoRemove::SuggestsImportant "false";' > /etc/apt/apt.conf.d/docker-autoremove-suggests`, false},
@@ -238,8 +243,11 @@ func TestImageManifestV1_LinuxAmd64(t *testing.T) {
 }
 
 var imageLinuxAmd64 = image{
-	url:      "https://test/v2/user/repo/manifests/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f",
-	platform: "linux/amd64",
+	url:        "https://test/v2/user/repo/manifests/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f",
+	platform:   "linux/amd64",
+	env:        []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "DEBIAN_FRONTEND=noninteractive"},
+	entrypoint: []string{"/docker-entrypoint.sh"},
+	cmd:        []string{"envoy", "-c", "/etc/envoy/envoy.yaml"},
 	filesystemLayers: []filesystemLayer{
 		{
 			url:       "https://test/v2/user/repo/blobs/sha256:01bf7da0a88c9e37ae418d17c0aeed0621524848d80ccb9e38c67e7ab8e11928",

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -40,14 +40,29 @@ import (
 type image struct {
 	internal.CarOnly
 
-	url              string
-	platform         string
-	filesystemLayers []filesystemLayer
+	url, platform        string
+	env, entrypoint, cmd []string
+	filesystemLayers     []filesystemLayer
 }
 
 // Platform implements the same method as documented on api.Image
 func (i image) Platform() string {
 	return i.platform
+}
+
+// Env implements the same method as documented on api.Image
+func (i image) Env() []string {
+	return i.env
+}
+
+// Entrypoint implements the same method as documented on api.Image
+func (i image) Entrypoint() []string {
+	return i.entrypoint
+}
+
+// Cmd implements the same method as documented on api.Image
+func (i image) Cmd() []string {
+	return i.cmd
 }
 
 // FilesystemLayerCount implements the same method as documented on api.Image

--- a/internal/registry/testdata/json/linux-amd64-vnd.docker.container.image.v1.json
+++ b/internal/registry/testdata/json/linux-amd64-vnd.docker.container.image.v1.json
@@ -1,6 +1,20 @@
 {
   "architecture": "amd64",
   "os": "linux",
+  "config": {
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "DEBIAN_FRONTEND=noninteractive"
+    ],
+    "Entrypoint": [
+      "/docker-entrypoint.sh"
+    ],
+    "Cmd": [
+      "envoy",
+      "-c",
+      "/etc/envoy/envoy.yaml"
+    ]
+  },
   "history": [
     {
       "created_by": "/bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / "


### PR DESCRIPTION
This parses the only fields used in wasm containers.

The wasm args == append(entrypoint, cmd...)

I'll leave this draft until I get things integrated in dapr.