### PR TITLE
Extracts api.Reference and Registry

### DIFF
--- a/car.go
+++ b/car.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package car
+
+import (
+	"context"
+
+	"github.com/tetratelabs/car/api"
+	"github.com/tetratelabs/car/internal/reference"
+	"github.com/tetratelabs/car/internal/registry"
+)
+
+// ParseReference is a simplified parser of OCI references that handle Docker
+// familiar images. This is not strict, so a bad url will result in an HTTP
+// error.
+func ParseReference(ref string) (r api.Reference, err error) {
+	return reference.Parse(ref)
+}
+
+// NewRegistry returns a new api.Registry appropriate for a Domain in an api.Reference.
+func NewRegistry(ctx context.Context, refDomain string) (api.Registry, error) {
+	return registry.New(ctx, refDomain)
+}

--- a/cmd/car/car_test.go
+++ b/cmd/car/car_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/car/api"
 	"github.com/tetratelabs/car/internal/registry/fake"
 )
 
@@ -154,9 +155,9 @@ usr/local/bin/car
 		t.Run(tt.name, func(t *testing.T) {
 			exitCode, stdout, stderr := runMain(t, "", tt.args)
 
-			require.Equal(t, tt.expectedStatus, exitCode)
 			require.Equal(t, tt.expectedStderr, stderr)
 			require.Equal(t, tt.expectedStdout, stdout)
+			require.Equal(t, tt.expectedStatus, exitCode)
 		})
 	}
 }
@@ -192,7 +193,9 @@ func runMain(t *testing.T, workdir string, args []string) (int, string, string) 
 		}()
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
-		doMain(context.Background(), fake.NewRegistry, &stdout, &stderr, func(code int) {
+		doMain(context.Background(), func(ctx context.Context, host string) (api.Registry, error) {
+			return fake.Registry, nil
+		}, &stdout, &stderr, func(code int) {
 			exitCode = code
 			panic(code) // to exit the func and set the exit status.
 		})

--- a/cmd/car/flags_test.go
+++ b/cmd/car/flags_test.go
@@ -150,6 +150,8 @@ func Test_platformValue(t *testing.T) {
 	}
 }
 
+// Test_referenceValue only covers a couple cases to avoid duplicating tests in
+// the reference package.
 func Test_referenceValue(t *testing.T) {
 	tests := []struct{ name, reference, expectedDomain, expectedPath, expectedTag, expectedErr string }{
 		{
@@ -160,82 +162,9 @@ func Test_referenceValue(t *testing.T) {
 			expectedTag:    "v1.18.3",
 		},
 		{
-			name:           "docker fully qualified",
-			reference:      "docker.io/envoyproxy/envoy:v1.18.3",
-			expectedDomain: "docker.io",
-			expectedPath:   "envoyproxy/envoy",
-			expectedTag:    "v1.18.3",
-		},
-		{
-			name:           "docker familiar official",
-			reference:      "alpine:3.14.0",
-			expectedDomain: "docker.io",
-			expectedPath:   "library/alpine",
-			expectedTag:    "3.14.0",
-		},
-		{
-			name:           "docker unfamiliar official",
-			reference:      "docker.io/library/alpine:3.14.0",
-			expectedDomain: "docker.io",
-			expectedPath:   "library/alpine",
-			expectedTag:    "3.14.0",
-		},
-		{
-			name:           "ghcr.io",
-			reference:      "ghcr.io/tetratelabs/car:latest",
-			expectedDomain: "ghcr.io",
-			expectedPath:   "tetratelabs/car",
-			expectedTag:    "latest",
-		},
-		{
-			name:           "ghcr.io multiple slashes",
-			reference:      "ghcr.io/homebrew/core/envoy:1.18.3-1",
-			expectedDomain: "ghcr.io",
-			expectedPath:   "homebrew/core/envoy",
-			expectedTag:    "1.18.3-1",
-		},
-		{
-			name:           "port 5443",
-			reference:      "localhost:5443/tetratelabs/car:latest",
-			expectedDomain: "localhost:5443",
-			expectedPath:   "tetratelabs/car",
-			expectedTag:    "latest",
-		},
-		{
-			name:           "port 5000 (localhost)",
-			reference:      "localhost:5000/tetratelabs/car:latest",
-			expectedDomain: "localhost:5000",
-			expectedPath:   "tetratelabs/car",
-			expectedTag:    "latest",
-		},
-		{
-			name:           "port 5000 (127.0.0.1)",
-			reference:      "127.0.0.1:5000/tetratelabs/car:latest",
-			expectedDomain: "127.0.0.1:5000",
-			expectedPath:   "tetratelabs/car",
-			expectedTag:    "latest",
-		},
-		{
-			name:           "port 5000 (e.g. docker compose)",
-			reference:      "registry:5000/tetratelabs/car:latest",
-			expectedDomain: "registry:5000",
-			expectedPath:   "tetratelabs/car",
-			expectedTag:    "latest",
-		},
-		{
 			name:        "empty",
 			reference:   "",
 			expectedErr: "invalid reference format",
-		},
-		{
-			name:        "docker familiar, but no tag",
-			reference:   "foo/bar",
-			expectedErr: "expected tagged reference",
-		},
-		{
-			name:        "missing tag",
-			reference:   "registry:5000/tetratelabs/car",
-			expectedErr: "expected tagged reference",
 		},
 	}
 
@@ -249,10 +178,9 @@ func Test_referenceValue(t *testing.T) {
 				require.EqualError(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
-				domain, path, tag := r.Get()
-				require.Equal(t, tc.expectedDomain, domain)
-				require.Equal(t, tc.expectedPath, path)
-				require.Equal(t, tc.expectedTag, tag)
+				require.Equal(t, tc.expectedDomain, r.r.Domain())
+				require.Equal(t, tc.expectedPath, r.r.Path())
+				require.Equal(t, tc.expectedTag, r.r.Tag())
 			}
 		})
 	}

--- a/internal/car/car_test.go
+++ b/internal/car/car_test.go
@@ -17,7 +17,6 @@ package car
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -25,11 +24,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/car/internal/reference"
 	"github.com/tetratelabs/car/internal/registry/fake"
 )
 
 func TestList(t *testing.T) {
-	tag := "v1.0"
+	ref := reference.MustParse("ghcr.io/tetratelabs/car:v1.0")
 	platform := "linux/amd64"
 
 	tests := []struct {
@@ -84,11 +84,9 @@ usr/local/bin/car
 			fastRead:    true,
 			veryVerbose: true,
 			patterns:    []string{"usr/local/bin/car"},
-			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
-fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
-CreatedBy: ADD build/* /usr/local/bin/ # buildkit
+			expectedOut: `linux/amd64
+4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f
+15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
 `,
 		},
@@ -112,19 +110,15 @@ usr/local/sbin/car
 		{
 			name:        "veryVerbose",
 			veryVerbose: true,
-			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
+			expectedOut: `linux/amd64
+4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f
 -rw-r-----	10	Jun  7 06:28:15	bin/apple.txt
 -rwxr-xr-x	20	Apr 16 22:53:09	usr/local/bin/boat
-fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
-CreatedBy: ADD build/* /usr/local/bin/ # buildkit
+15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
-fake://ghcr.io/v2/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=40
-CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
+1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81
 -rw-r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
-fake://ghcr.io/v2/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=50
-CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
+6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241
 -rwxr-xr-x	50	May 12 03:53:29	usr/local/sbin/car
 `,
 		},
@@ -136,10 +130,9 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			var stdout bytes.Buffer
-			r, err := fake.NewRegistry(ctx, "ghcr.io")
-			require.NoError(t, err)
+
 			c := New(
-				r,
+				fake.Registry,
 				&stdout,
 				tc.createdByPattern,
 				tc.patterns,
@@ -148,8 +141,7 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 				tc.veryVerbose,
 			)
 
-			err = c.List(ctx, "tetratelabs/car", tag, platform)
-			if tc.expectedErr != "" {
+			if err := c.List(ctx, ref, platform); tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 				require.Equal(t, tc.expectedOut, stdout.String())
 			} else {
@@ -161,7 +153,7 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 }
 
 func TestExtract(t *testing.T) {
-	tag := "v1.0"
+	ref := reference.MustParse("ghcr.io/tetratelabs/car:v1.0")
 	platform := "linux/amd64"
 	allFilesToSizes := map[string]int64{
 		"bin/apple.txt":                         10,
@@ -227,11 +219,9 @@ func TestExtract(t *testing.T) {
 			expectedFileToSizes: map[string]int64{
 				"usr/local/bin/car": 30,
 			},
-			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
-fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
-CreatedBy: ADD build/* /usr/local/bin/ # buildkit
+			expectedOut: `linux/amd64
+4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f
+15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
 `,
 		},
@@ -281,19 +271,15 @@ usr/local/sbin/car
 			name:                "veryVerbose",
 			veryVerbose:         true,
 			expectedFileToSizes: allFilesToSizes,
-			expectedOut: `fake://ghcr.io/v2/tetratelabs/car/manifests/v1.0 platform=linux/amd64 totalLayerSize: 150
-fake://ghcr.io/v2/blobs/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f size=30
-CreatedBy: /bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in /
+			expectedOut: `linux/amd64
+4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f
 -rw-r-----	10	Jun  7 06:28:15	bin/apple.txt
 -rwxr-xr-x	20	Apr 16 22:53:09	usr/local/bin/boat
-fake://ghcr.io/v2/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2 size=30
-CreatedBy: ADD build/* /usr/local/bin/ # buildkit
+15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2
 -rwxr-xr-x	30	May 12 03:53:29	usr/local/bin/car
-fake://ghcr.io/v2/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81 size=40
-CreatedBy: cmd /S /C powershell iex(iwr -useb https://moretrucks.io/install.ps1)
+1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81
 -rw-r--r--	40	May 12 03:53:15	Files/ProgramData/truck/bin/truck.exe
-fake://ghcr.io/v2/blobs/sha256:6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241 size=50
-CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
+6d2d8da2960b0044c22730be087e6d7b197ab215d78f9090a3dff8cb7c40c241
 -rwxr-xr-x	50	May 12 03:53:29	usr/local/sbin/car
 `,
 		},
@@ -305,10 +291,8 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			var stdout bytes.Buffer
-			r, err := fake.NewRegistry(ctx, "ghcr.io")
-			require.NoError(t, err)
 			c := New(
-				r,
+				fake.Registry,
 				&stdout,
 				tc.createdByPattern,
 				tc.patterns,
@@ -317,12 +301,8 @@ CreatedBy: ADD build/* /usr/local/sbin/ # buildkit
 				tc.veryVerbose,
 			)
 
-			directory, err := ioutil.TempDir("", "")
-			require.NoError(t, err, `ioutil.TempDir("", "") erred`)
-			defer os.RemoveAll(directory) //nolint
-
-			err = c.Extract(ctx, "tetratelabs/car", tag, platform, directory, tc.stripComponents)
-			if tc.expectedErr != "" {
+			directory := t.TempDir()
+			if err := c.Extract(ctx, ref, platform, directory, tc.stripComponents); tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 				require.Equal(t, tc.expectedOut, stdout.String())
 			} else {

--- a/internal/httpclient/http.go
+++ b/internal/httpclient/http.go
@@ -26,7 +26,7 @@ import (
 
 // HTTPClient is a convenience wrapper for http.Client that consolidates common logic.
 type HTTPClient interface {
-	// Get returns the body and media type of the URL using the provided context. The caller must close the body.
+	// Get returns the body and media type of the url using the provided context. The caller must close the body.
 	//
 	// This is optimized for easy content negotiation. Hence, the returned mediaType is stripped of qualifiers.
 	// e.g. "Content-Type: application/json; charset=utf-8" will return mediaType "application/json"

--- a/internal/httpclient/http.go
+++ b/internal/httpclient/http.go
@@ -26,7 +26,7 @@ import (
 
 // HTTPClient is a convenience wrapper for http.Client that consolidates common logic.
 type HTTPClient interface {
-	// Get returns the body and media type of the url using the provided context. The caller must close the body.
+	// Get returns the body and media type of the URL using the provided context. The caller must close the body.
 	//
 	// This is optimized for easy content negotiation. Hence, the returned mediaType is stripped of qualifiers.
 	// e.g. "Content-Type: application/json; charset=utf-8" will return mediaType "application/json"

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// CarOnly indicates by type the implementation is internal only.
+//
+// Design credit to https://github.com/tetratelabs/wazero/pull/1396
+type CarOnly interface {
+	carOnly()
+}
+
+type CarOnlyType struct{}
+
+func (CarOnlyType) carOnly() {}

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -1,0 +1,97 @@
+// Copyright 2023 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reference
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/tetratelabs/car/internal"
+)
+
+type Reference struct {
+	internal.CarOnly
+
+	domain, path, tag string
+}
+
+// MustParse calls Parse or panics on error.
+func MustParse(ref string) *Reference {
+	r, err := Parse(ref)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// Parse is a simplified parser of OCI references that handle Docker
+// familiar images. This is not strict, so a bad url will result in an HTTP
+// error.
+func Parse(ref string) (r *Reference, err error) {
+	if ref == "" {
+		err = errors.New("invalid reference format")
+		return
+	}
+
+	// First, check to see if there's at least one colon. If not, this cannot
+	// be a tagged image.
+	indexColon := strings.LastIndexByte(ref, byte(':'))
+	indexSlash := strings.IndexByte(ref, byte('/'))
+	if indexColon == -1 || indexSlash > indexColon /* e.g. host:80/image */ {
+		err = errors.New("expected tagged reference")
+		return
+
+	}
+
+	r = &Reference{}
+	r.tag = ref[indexColon+1:]
+	remaining := ref[0:indexColon]
+
+	// See if this is a familiar official docker image. e.g. "alpine:3.14.0"
+	if indexSlash == -1 {
+		r.domain = "docker.io"
+		r.path = "library/" + remaining
+		return
+	}
+
+	// See if this is an official docker image. e.g. "envoyproxy/envoy:v1.18.3"
+	if strings.LastIndexByte(ref, byte('/')) == indexSlash {
+		r.domain = "docker.io"
+		r.path = remaining
+		return
+	}
+
+	// Otherwise, the part leading to the first slash is the domain.
+	r.domain = remaining[0:indexSlash]
+	r.path = remaining[indexSlash+1:]
+	return
+}
+
+func (r *Reference) Domain() string {
+	return r.domain
+}
+
+func (r *Reference) Path() string {
+	return r.path
+}
+
+func (r *Reference) Tag() string {
+	return r.tag
+}
+
+// String implements fmt.Stringer
+func (r *Reference) String() string {
+	return r.domain + "/" + r.path + "/" + r.tag
+}

--- a/internal/reference/reference_test.go
+++ b/internal/reference/reference_test.go
@@ -1,0 +1,127 @@
+// Copyright 2023 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reference
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Parse(t *testing.T) {
+	tests := []struct{ name, reference, expectedDomain, expectedPath, expectedTag, expectedErr string }{
+		{
+			name:           "docker familiar",
+			reference:      "envoyproxy/envoy:v1.18.3",
+			expectedDomain: "docker.io",
+			expectedPath:   "envoyproxy/envoy",
+			expectedTag:    "v1.18.3",
+		},
+		{
+			name:           "docker fully qualified",
+			reference:      "docker.io/envoyproxy/envoy:v1.18.3",
+			expectedDomain: "docker.io",
+			expectedPath:   "envoyproxy/envoy",
+			expectedTag:    "v1.18.3",
+		},
+		{
+			name:           "docker familiar official",
+			reference:      "alpine:3.14.0",
+			expectedDomain: "docker.io",
+			expectedPath:   "library/alpine",
+			expectedTag:    "3.14.0",
+		},
+		{
+			name:           "docker unfamiliar official",
+			reference:      "docker.io/library/alpine:3.14.0",
+			expectedDomain: "docker.io",
+			expectedPath:   "library/alpine",
+			expectedTag:    "3.14.0",
+		},
+		{
+			name:           "ghcr.io",
+			reference:      "ghcr.io/tetratelabs/car:latest",
+			expectedDomain: "ghcr.io",
+			expectedPath:   "tetratelabs/car",
+			expectedTag:    "latest",
+		},
+		{
+			name:           "ghcr.io multiple slashes",
+			reference:      "ghcr.io/homebrew/core/envoy:1.18.3-1",
+			expectedDomain: "ghcr.io",
+			expectedPath:   "homebrew/core/envoy",
+			expectedTag:    "1.18.3-1",
+		},
+		{
+			name:           "port 5443",
+			reference:      "localhost:5443/tetratelabs/car:latest",
+			expectedDomain: "localhost:5443",
+			expectedPath:   "tetratelabs/car",
+			expectedTag:    "latest",
+		},
+		{
+			name:           "port 5000 (localhost)",
+			reference:      "localhost:5000/tetratelabs/car:latest",
+			expectedDomain: "localhost:5000",
+			expectedPath:   "tetratelabs/car",
+			expectedTag:    "latest",
+		},
+		{
+			name:           "port 5000 (127.0.0.1)",
+			reference:      "127.0.0.1:5000/tetratelabs/car:latest",
+			expectedDomain: "127.0.0.1:5000",
+			expectedPath:   "tetratelabs/car",
+			expectedTag:    "latest",
+		},
+		{
+			name:           "port 5000 (e.g. docker compose)",
+			reference:      "registry:5000/tetratelabs/car:latest",
+			expectedDomain: "registry:5000",
+			expectedPath:   "tetratelabs/car",
+			expectedTag:    "latest",
+		},
+		{
+			name:        "empty",
+			reference:   "",
+			expectedErr: "invalid reference format",
+		},
+		{
+			name:        "docker familiar, but no tag",
+			reference:   "foo/bar",
+			expectedErr: "expected tagged reference",
+		},
+		{
+			name:        "missing tag",
+			reference:   "registry:5000/tetratelabs/car",
+			expectedErr: "expected tagged reference",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // pin! see https://github.com/kyoh86/scopelint for why
+
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := Parse(tc.reference)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedDomain, r.domain)
+				require.Equal(t, tc.expectedPath, r.path)
+				require.Equal(t, tc.expectedTag, r.tag)
+			}
+		})
+	}
+}

--- a/internal/registry/fake/fake_test.go
+++ b/internal/registry/fake/fake_test.go
@@ -23,36 +23,21 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/car/internal"
+	"github.com/tetratelabs/car/internal/reference"
 )
 
-func TestNewRegistry(t *testing.T) {
-	var nr internal.NewRegistry = NewRegistry // ensure it matches signature
-
-	r, err := nr(context.Background(), "ghcr.io")
-	require.NoError(t, err)
-	require.Equal(t, "fake://ghcr.io/v2", r.(*fakeRegistry).baseURL)
-	require.Equal(t, "v1.0", r.(*fakeRegistry).tag)
-
-	require.Equal(t, "linux/amd64", r.(*fakeRegistry).platform)
-	require.Equal(t, 4, len(r.(*fakeRegistry).filesystemLayers))
-}
-
 func TestGetImage(t *testing.T) {
-	r, err := NewRegistry(context.Background(), "ghcr.io")
-	require.NoError(t, err)
+	ref := reference.MustParse("ghcr.io/tetratelabs/car:v1.0")
 
-	i, err := r.GetImage(context.Background(), "tetratelabs/car", "v1.0", "linux/amd64")
+	i, err := Registry.GetImage(context.Background(), ref, "linux/amd64")
 	require.NoError(t, err)
-	require.Equal(t, r.(*fakeRegistry).filesystemLayers, i.FilesystemLayers)
+	require.Equal(t, "linux/amd64", i.Platform())
 }
 
 func TestReadFilesystemLayer(t *testing.T) {
-	r, err := NewRegistry(context.Background(), "ghcr.io")
-	require.NoError(t, err)
-	layer := r.(*fakeRegistry).filesystemLayers[0]
+	layer := fakeFilesystemLayers[0]
 	i := 0
-	err = r.ReadFilesystemLayer(context.Background(), layer,
+	err := Registry.ReadFilesystemLayer(context.Background(), layer,
 		func(name string, size int64, mode os.FileMode, modTime time.Time, reader io.Reader) error {
 			require.Equal(t, fakeFiles[0][i].name, name)
 			require.Equal(t, fakeFiles[0][i].size, size)

--- a/internal/registry/json_test.go
+++ b/internal/registry/json_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/car/internal"
+	"github.com/tetratelabs/car/api"
 )
 
 //go:embed testdata/json/homebrew-11.3-vnd.oci.image.config.v1.json
@@ -48,12 +48,12 @@ func TestImageIndexV1_Homebrew(t *testing.T) {
 	require.Equal(t, imageIndexV1{
 		Manifests: []*imageManifestReferenceV1{
 			{
-				MediaType: mediaTypeOCIImageManifest,
+				MediaType: api.MediaTypeOCIImageManifest,
 				Digest:    "sha256:0da7ea4ca0f3615ace3b2223248e0baed539223df62d33d4c1a1e23346329057",
 				Platform:  platformV1{"amd64", "darwin", "macOS 10.15.7"},
 			},
 			{
-				MediaType: mediaTypeOCIImageManifest,
+				MediaType: api.MediaTypeOCIImageManifest,
 				Digest:    "sha256:03efb0078d32e24f3730afb13fc58b635bd4e9c6d5ab32b90af3922efc7f8672",
 				Platform:  platformV1{"amd64", "darwin", "macOS 11.3"},
 			},
@@ -70,12 +70,12 @@ func TestImageManifestV1_Homebrew(t *testing.T) {
 
 	require.Equal(t, imageManifestV1{
 		Config: descriptorV1{
-			MediaType: mediaTypeOCIImageConfig,
+			MediaType: api.MediaTypeOCIImageConfig,
 			Digest:    "sha256:a7f8bac78026ae40545531454c2ef4df75ec3de1c60f1d6923142fe4e44daf8a",
 		},
 		Layers: []descriptorV1{
 			{
-				MediaType: mediaTypeOCIImageLayer,
+				MediaType: api.MediaTypeOCIImageLayer,
 				Digest:    "sha256:d03fb86b48336c8d3c0f3711cfc3df3557f9fb33c966ceb1caecae1653935e90",
 				Size:      29405739,
 			},
@@ -83,14 +83,14 @@ func TestImageManifestV1_Homebrew(t *testing.T) {
 	}, v)
 }
 
-var imageHomebrew = &internal.Image{
-	URL:      "https://test/v2/user/repo/manifests/sha256:03efb0078d32e24f3730afb13fc58b635bd4e9c6d5ab32b90af3922efc7f8672",
-	Platform: "darwin/amd64",
-	FilesystemLayers: []*internal.FilesystemLayer{
+var imageHomebrew = image{
+	url:      "https://test/v2/user/repo/manifests/sha256:03efb0078d32e24f3730afb13fc58b635bd4e9c6d5ab32b90af3922efc7f8672",
+	platform: "darwin/amd64",
+	filesystemLayers: []filesystemLayer{
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:d03fb86b48336c8d3c0f3711cfc3df3557f9fb33c966ceb1caecae1653935e90",
-			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
-			Size:      29405739,
+			url:       "https://test/v2/user/repo/blobs/sha256:d03fb86b48336c8d3c0f3711cfc3df3557f9fb33c966ceb1caecae1653935e90",
+			mediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+			size:      29405739,
 		},
 	},
 }
@@ -150,12 +150,12 @@ func TestImageIndexV1_Linux(t *testing.T) {
 	require.Equal(t, imageIndexV1{
 		Manifests: []*imageManifestReferenceV1{
 			{
-				MediaType: mediaTypeDockerManifest,
+				MediaType: api.MediaTypeDockerManifest,
 				Digest:    "sha256:f1cb90d4df0521842fe5f5c01a00032c76ba1743e1b2477589103373af06707c",
 				Platform:  platformV1{"arm64", "linux", ""},
 			},
 			{
-				MediaType: mediaTypeDockerManifest,
+				MediaType: api.MediaTypeDockerManifest,
 				Digest:    "sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f",
 				Platform:  platformV1{"amd64", "linux", ""},
 			},
@@ -177,57 +177,57 @@ func TestImageManifestV1_LinuxAmd64(t *testing.T) {
 		t,
 		imageManifestV1{
 			Config: descriptorV1{
-				MediaType: mediaTypeDockerContainerImage,
+				MediaType: api.MediaTypeDockerContainerImage,
 				Digest:    "sha256:33655f17f09318801873b70f89c1596ce38f41f6c074e2343d26e9b425f939ec",
 			},
 			Layers: []descriptorV1{
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:01bf7da0a88c9e37ae418d17c0aeed0621524848d80ccb9e38c67e7ab8e11928",
 					Size:      26697009,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:f3b4a5f15c7a0722b4f22e61b5387317eaf2602c27ffb2bceac9a25f19fbd156",
 					Size:      852,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:57ffbe87baa135002dddb7a7460082c5d6a352186e1be9464c5f31db81378824",
 					Size:      188,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:e2f93437f92e69c54acb27971690e8fe49ba75783cc2e6d5b0efbaa971d73fba",
 					Size:      2922771,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:21cb341b2283d5501142f9e4f9d1b1941138ccc0777b8914b18f842b42d1571c",
 					Size:      120,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2",
 					Size:      21729278,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:3e05f50f195e6d16485c6a693092169b274d399d3cce98a87dd36c007a6911c3",
 					Size:      749,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81",
 					Size:      3500,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:2fb3fe4b571942f3d49d9c0ab84550cfa3843936278ce4e58dba28934efeff72",
 					Size:      1467,
 				},
 				{
-					MediaType: mediaTypeDockerImageLayer,
+					MediaType: api.MediaTypeDockerImageLayer,
 					Digest:    "sha256:68cf5c71735e492dc26366a69455c30b52e0787ebb8604909f77741f19883aeb",
 					Size:      490,
 				},
@@ -237,69 +237,69 @@ func TestImageManifestV1_LinuxAmd64(t *testing.T) {
 	)
 }
 
-var imageLinuxAmd64 = &internal.Image{
-	URL:      "https://test/v2/user/repo/manifests/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f",
-	Platform: "linux/amd64",
-	FilesystemLayers: []*internal.FilesystemLayer{
+var imageLinuxAmd64 = image{
+	url:      "https://test/v2/user/repo/manifests/sha256:4e07f3bd88fb4a468d5551c21eb05f625b0efe9ee00ae25d3ffb87c0f563693f",
+	platform: "linux/amd64",
+	filesystemLayers: []filesystemLayer{
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:01bf7da0a88c9e37ae418d17c0aeed0621524848d80ccb9e38c67e7ab8e11928",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      26697009,
-			CreatedBy: `/bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / `,
+			url:       "https://test/v2/user/repo/blobs/sha256:01bf7da0a88c9e37ae418d17c0aeed0621524848d80ccb9e38c67e7ab8e11928",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      26697009,
+			createdBy: `/bin/sh -c #(nop) ADD file:d7fa3c26651f9204a5629287a1a9a6e7dc6a0bc6eb499e82c433c0c8f67ff46b in / `,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:f3b4a5f15c7a0722b4f22e61b5387317eaf2602c27ffb2bceac9a25f19fbd156",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      852,
-			CreatedBy: `/bin/sh -c set -xe 		&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d 	&& echo 'exit 101' >> /usr/sbin/policy-rc.d 	&& chmod +x /usr/sbin/policy-rc.d 		&& dpkg-divert --local --rename --add /sbin/initctl 	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl 	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl 		&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup 		&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean 		&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages 		&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes 		&& echo 'Apt::AutoRemove::SuggestsImportant "false";' > /etc/apt/apt.conf.d/docker-autoremove-suggests`,
+			url:       "https://test/v2/user/repo/blobs/sha256:f3b4a5f15c7a0722b4f22e61b5387317eaf2602c27ffb2bceac9a25f19fbd156",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      852,
+			createdBy: `/bin/sh -c set -xe 		&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d 	&& echo 'exit 101' >> /usr/sbin/policy-rc.d 	&& chmod +x /usr/sbin/policy-rc.d 		&& dpkg-divert --local --rename --add /sbin/initctl 	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl 	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl 		&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup 		&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean 		&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages 		&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes 		&& echo 'Apt::AutoRemove::SuggestsImportant "false";' > /etc/apt/apt.conf.d/docker-autoremove-suggests`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:57ffbe87baa135002dddb7a7460082c5d6a352186e1be9464c5f31db81378824",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      188,
-			CreatedBy: `/bin/sh -c mkdir -p /run/systemd && echo 'docker' > /run/systemd/container`,
+			url:       "https://test/v2/user/repo/blobs/sha256:57ffbe87baa135002dddb7a7460082c5d6a352186e1be9464c5f31db81378824",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      188,
+			createdBy: `/bin/sh -c mkdir -p /run/systemd && echo 'docker' > /run/systemd/container`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:e2f93437f92e69c54acb27971690e8fe49ba75783cc2e6d5b0efbaa971d73fba",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      2922771,
-			CreatedBy: `RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c apt-get update && apt-get upgrade -y     && apt-get install --no-install-recommends -y ca-certificates     && apt-get autoremove -y && apt-get clean     && rm -rf /tmp/* /var/tmp/*     && rm -rf /var/lib/apt/lists/* # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:e2f93437f92e69c54acb27971690e8fe49ba75783cc2e6d5b0efbaa971d73fba",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      2922771,
+			createdBy: `RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c apt-get update && apt-get upgrade -y     && apt-get install --no-install-recommends -y ca-certificates     && apt-get autoremove -y && apt-get clean     && rm -rf /tmp/* /var/tmp/*     && rm -rf /var/lib/apt/lists/* # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:21cb341b2283d5501142f9e4f9d1b1941138ccc0777b8914b18f842b42d1571c",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      120,
-			CreatedBy: `RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c mkdir -p /etc/envoy # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:21cb341b2283d5501142f9e4f9d1b1941138ccc0777b8914b18f842b42d1571c",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      120,
+			createdBy: `RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c mkdir -p /etc/envoy # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      21729278,
-			CreatedBy: `ADD linux/amd64/build_release_stripped/* /usr/local/bin/ # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:15a7c58f96c57b941a56cbf1bdd525cdef1773a7671c52b7039047a1941105c2",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      21729278,
+			createdBy: `ADD linux/amd64/build_release_stripped/* /usr/local/bin/ # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:3e05f50f195e6d16485c6a693092169b274d399d3cce98a87dd36c007a6911c3",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      749,
-			CreatedBy: `ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:3e05f50f195e6d16485c6a693092169b274d399d3cce98a87dd36c007a6911c3",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      749,
+			createdBy: `ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      3500,
-			CreatedBy: `ADD linux/amd64/build_release/su-exec /usr/local/bin/ # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:1b68df344f018b7cdd39908b93b6d60792a414cbf47975f7606a18bd603e6a81",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      3500,
+			createdBy: `ADD linux/amd64/build_release/su-exec /usr/local/bin/ # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:2fb3fe4b571942f3d49d9c0ab84550cfa3843936278ce4e58dba28934efeff72",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      1467,
-			CreatedBy: `RUN |2 TARGETPLATFORM=linux/amd64 ENVOY_BINARY_SUFFIX=_stripped /bin/sh -c chown root:root /usr/local/bin/su-exec && adduser --group --system envoy # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:2fb3fe4b571942f3d49d9c0ab84550cfa3843936278ce4e58dba28934efeff72",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      1467,
+			createdBy: `RUN |2 TARGETPLATFORM=linux/amd64 ENVOY_BINARY_SUFFIX=_stripped /bin/sh -c chown root:root /usr/local/bin/su-exec && adduser --group --system envoy # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:68cf5c71735e492dc26366a69455c30b52e0787ebb8604909f77741f19883aeb",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      490,
-			CreatedBy: `COPY ci/docker-entrypoint.sh / # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:68cf5c71735e492dc26366a69455c30b52e0787ebb8604909f77741f19883aeb",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      490,
+			createdBy: `COPY ci/docker-entrypoint.sh / # buildkit`,
 		},
 	},
 }
@@ -314,69 +314,69 @@ func TestNewImage_LinuxAmd64(t *testing.T) {
 	require.Equal(t, imageLinuxAmd64, newImage("https://test/v2/user/repo", &i, &c))
 }
 
-var imageLinuxArm64 = &internal.Image{
-	URL:      "https://test/v2/user/repo/manifests/sha256:f1cb90d4df0521842fe5f5c01a00032c76ba1743e1b2477589103373af06707c",
-	Platform: "linux/arm64",
-	FilesystemLayers: []*internal.FilesystemLayer{
+var imageLinuxArm64 = image{
+	url:      "https://test/v2/user/repo/manifests/sha256:f1cb90d4df0521842fe5f5c01a00032c76ba1743e1b2477589103373af06707c",
+	platform: "linux/arm64",
+	filesystemLayers: []filesystemLayer{
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:673aeee5c81c892477834e2b5e55575f16bfd52d9b841a1d8c524fb3805ee960",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      23703698,
-			CreatedBy: `/bin/sh -c #(nop) ADD file:5f7cb4b44f843eaef6ae7ddb75dfc228a33d20cd974074ca23c1bb2cad7f77ad in / `,
+			url:       "https://test/v2/user/repo/blobs/sha256:673aeee5c81c892477834e2b5e55575f16bfd52d9b841a1d8c524fb3805ee960",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      23703698,
+			createdBy: `/bin/sh -c #(nop) ADD file:5f7cb4b44f843eaef6ae7ddb75dfc228a33d20cd974074ca23c1bb2cad7f77ad in / `,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:018b2790219d2003c0d437e634927887ee5cc3d8f985d7459adc5b2ff62d003f",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      851,
-			CreatedBy: `/bin/sh -c set -xe 		&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d 	&& echo 'exit 101' >> /usr/sbin/policy-rc.d 	&& chmod +x /usr/sbin/policy-rc.d 		&& dpkg-divert --local --rename --add /sbin/initctl 	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl 	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl 		&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup 		&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean 		&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages 		&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes 		&& echo 'Apt::AutoRemove::SuggestsImportant "false";' > /etc/apt/apt.conf.d/docker-autoremove-suggests`,
+			url:       "https://test/v2/user/repo/blobs/sha256:018b2790219d2003c0d437e634927887ee5cc3d8f985d7459adc5b2ff62d003f",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      851,
+			createdBy: `/bin/sh -c set -xe 		&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d 	&& echo 'exit 101' >> /usr/sbin/policy-rc.d 	&& chmod +x /usr/sbin/policy-rc.d 		&& dpkg-divert --local --rename --add /sbin/initctl 	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl 	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl 		&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup 		&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean 		&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages 		&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes 		&& echo 'Apt::AutoRemove::SuggestsImportant "false";' > /etc/apt/apt.conf.d/docker-autoremove-suggests`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:509c77ce92ade89fbf09fe03b167023be51bf5a0c14c00487fa7a9ee33b55fc3",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      187,
-			CreatedBy: `/bin/sh -c mkdir -p /run/systemd && echo 'docker' > /run/systemd/container`,
+			url:       "https://test/v2/user/repo/blobs/sha256:509c77ce92ade89fbf09fe03b167023be51bf5a0c14c00487fa7a9ee33b55fc3",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      187,
+			createdBy: `/bin/sh -c mkdir -p /run/systemd && echo 'docker' > /run/systemd/container`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:1cfa500dd01835df61b905a437de186592fa2adf6d6a3694a26c13f76c72b1f6",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      2617240,
-			CreatedBy: `RUN |1 TARGETPLATFORM=linux/arm64 /bin/sh -c apt-get update && apt-get upgrade -y     && apt-get install --no-install-recommends -y ca-certificates     && apt-get autoremove -y && apt-get clean     && rm -rf /tmp/* /var/tmp/*     && rm -rf /var/lib/apt/lists/* # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:1cfa500dd01835df61b905a437de186592fa2adf6d6a3694a26c13f76c72b1f6",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      2617240,
+			createdBy: `RUN |1 TARGETPLATFORM=linux/arm64 /bin/sh -c apt-get update && apt-get upgrade -y     && apt-get install --no-install-recommends -y ca-certificates     && apt-get autoremove -y && apt-get clean     && rm -rf /tmp/* /var/tmp/*     && rm -rf /var/lib/apt/lists/* # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:57227c32adb08b6f11b734f43a3c621a25a35833d2eaff6047612deffabea67f",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      120,
-			CreatedBy: `RUN |1 TARGETPLATFORM=linux/arm64 /bin/sh -c mkdir -p /etc/envoy # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:57227c32adb08b6f11b734f43a3c621a25a35833d2eaff6047612deffabea67f",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      120,
+			createdBy: `RUN |1 TARGETPLATFORM=linux/arm64 /bin/sh -c mkdir -p /etc/envoy # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:97c59091ec632eb43a1f8ae51f48200b97a580b9fbf0c591ad5cccd12d2bd573",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      19994790,
-			CreatedBy: `ADD linux/arm64/build_release_stripped/* /usr/local/bin/ # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:97c59091ec632eb43a1f8ae51f48200b97a580b9fbf0c591ad5cccd12d2bd573",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      19994790,
+			createdBy: `ADD linux/arm64/build_release_stripped/* /usr/local/bin/ # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:2a7ca8a5ead0b680d1e00675e8f0a3ee864e64173e7150fd056bd72659f69bd6",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      746,
-			CreatedBy: `ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:2a7ca8a5ead0b680d1e00675e8f0a3ee864e64173e7150fd056bd72659f69bd6",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      746,
+			createdBy: `ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:af66acd072fe6384d76fe0f86ccf256a9a6ae9c6cb8b2b38c9ea4241cb92aeca",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      3888,
-			CreatedBy: `ADD linux/arm64/build_release/su-exec /usr/local/bin/ # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:af66acd072fe6384d76fe0f86ccf256a9a6ae9c6cb8b2b38c9ea4241cb92aeca",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      3888,
+			createdBy: `ADD linux/arm64/build_release/su-exec /usr/local/bin/ # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:f21ff7be3ac20eb86e923b81c6735b98f980e793bb88db26716944bb5f8730f0",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      1460,
-			CreatedBy: `RUN |2 TARGETPLATFORM=linux/arm64 ENVOY_BINARY_SUFFIX=_stripped /bin/sh -c chown root:root /usr/local/bin/su-exec && adduser --group --system envoy # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:f21ff7be3ac20eb86e923b81c6735b98f980e793bb88db26716944bb5f8730f0",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      1460,
+			createdBy: `RUN |2 TARGETPLATFORM=linux/arm64 ENVOY_BINARY_SUFFIX=_stripped /bin/sh -c chown root:root /usr/local/bin/su-exec && adduser --group --system envoy # buildkit`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:68cf5c71735e492dc26366a69455c30b52e0787ebb8604909f77741f19883aeb",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      490,
-			CreatedBy: `COPY ci/docker-entrypoint.sh / # buildkit`,
+			url:       "https://test/v2/user/repo/blobs/sha256:68cf5c71735e492dc26366a69455c30b52e0787ebb8604909f77741f19883aeb",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      490,
+			createdBy: `COPY ci/docker-entrypoint.sh / # buildkit`,
 		},
 	},
 }
@@ -388,8 +388,8 @@ func TestNewImage_LinuxArm64(t *testing.T) {
 	require.NoError(t, json.Unmarshal(linuxArm64VndDockerImageConfigV1Json, &config))
 	image.URL = "https://test/v2/user/repo/manifests/sha256:f1cb90d4df0521842fe5f5c01a00032c76ba1743e1b2477589103373af06707c"
 
-	for i := range imageLinuxArm64.FilesystemLayers {
-		require.Equal(t, imageLinuxArm64.FilesystemLayers[i], newImage("https://test/v2/user/repo", &image, &config).FilesystemLayers[i])
+	for i := range imageLinuxArm64.filesystemLayers {
+		require.Equal(t, imageLinuxArm64.filesystemLayers[i], newImage("https://test/v2/user/repo", &image, &config).FilesystemLayer(i))
 	}
 }
 
@@ -416,12 +416,12 @@ func TestImageManifestV1_WasmCompat(t *testing.T) {
 
 	require.Equal(t, imageManifestV1{
 		Config: descriptorV1{
-			MediaType: mediaTypeDockerContainerImage,
+			MediaType: api.MediaTypeDockerContainerImage,
 			Digest:    "sha256:453ac05d32d4a692870ff11cbee61edb7f05c4223ab772d10aaa37d5c150037a",
 		},
 		Layers: []descriptorV1{
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:d5e23ba78042fb166c603420339d92abb56a79bc8b689f4c84c96232a66be157",
 				Size:      116164,
 			},
@@ -429,15 +429,15 @@ func TestImageManifestV1_WasmCompat(t *testing.T) {
 	}, v)
 }
 
-var imageWasmCompat = &internal.Image{
-	URL:      "https://test/v2/user/repo/manifests/sha256:03efb0078d32e24f3730afb13fc58b635bd4e9c6d5ab32b90af3922efc7f8672",
-	Platform: "linux/amd64",
-	FilesystemLayers: []*internal.FilesystemLayer{
+var imageWasmCompat = image{
+	url:      "https://test/v2/user/repo/manifests/sha256:03efb0078d32e24f3730afb13fc58b635bd4e9c6d5ab32b90af3922efc7f8672",
+	platform: "linux/amd64",
+	filesystemLayers: []filesystemLayer{
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:d5e23ba78042fb166c603420339d92abb56a79bc8b689f4c84c96232a66be157",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      116164,
-			CreatedBy: "COPY plugin.wasm ./ # buildkit",
+			url:       "https://test/v2/user/repo/blobs/sha256:d5e23ba78042fb166c603420339d92abb56a79bc8b689f4c84c96232a66be157",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      116164,
+			createdBy: "COPY plugin.wasm ./ # buildkit",
 		},
 	},
 }
@@ -488,67 +488,67 @@ func TestImageManifestV1_Windows(t *testing.T) {
 
 	require.Equal(t, imageManifestV1{
 		Config: descriptorV1{
-			MediaType: mediaTypeDockerContainerImage,
+			MediaType: api.MediaTypeDockerContainerImage,
 			Digest:    "sha256:00378fa4979bfcc7d1f5d33bb8cebe526395021801f9e233f8909ffc25a6f630",
 		},
 		Layers: []descriptorV1{
 			{
-				MediaType: mediaTypeDockerImageForeignLayer,
+				MediaType: api.MediaTypeDockerImageForeignLayer,
 				Digest:    "sha256:4612f6d0b889cad0ed0292fae3a0b0c8a9e49aff6dea8eb049b2386d9b07986f",
 				Size:      1718332879,
 			},
 			{
-				MediaType: mediaTypeDockerImageForeignLayer,
+				MediaType: api.MediaTypeDockerImageForeignLayer,
 				Digest:    "sha256:399f118dfaa9a753e98d128238b944432c7bcabea88a2998a6efbbece28ed303",
 				Size:      751421005,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:47916aee02007e0e175e80deb2938cf8f95457b9abb555bd44dc461680dc552c",
 				Size:      323887,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:ba79ee4428b5ceec3026664126a146fd8c1041b478f3018ec0c90b78d7fe6355",
 				Size:      331919,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4",
 				Size:      12217107,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:0fcfdc906e922391139a1c2d8f5d600066fa3b21c720a4024831471e2a8f0011",
 				Size:      337530,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:f5ece8fbad694f5d1169c17ddd4217265cdf3dd886b71a8e9144f8b00e22de07",
 				Size:      2410,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:8d3db7768af4371ec3f749f6816c8450687e276a883b8ca626a1fc1402fd32e0",
 				Size:      419457,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:f0b13e108f65feef6ee7b28a639a516aa37082bca3e0ac332bcde1e97e095b6b",
 				Size:      1303,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:9e17bb8cfb82c53b1793341a2dfb555e63088b1594d81d2b01106fae9a8aa60b",
 				Size:      1745,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:30188a58a9ae8bd6cbfc36a6ba873a1a8cfe5a50993fc982844b935fa2724126",
 				Size:      1327,
 			},
 			{
-				MediaType: mediaTypeDockerImageLayer,
+				MediaType: api.MediaTypeDockerImageLayer,
 				Digest:    "sha256:ce93263143f489be1ca45bbda23e98dc97445fc9b3d53a7ffd4f7a7eb25889fc",
 				Size:      1334,
 			},
@@ -556,51 +556,51 @@ func TestImageManifestV1_Windows(t *testing.T) {
 	}, v)
 }
 
-var imageWindows = &internal.Image{
-	URL:      "https://test/v2/user/repo/manifests/v1.0",
-	Platform: "windows/amd64",
-	FilesystemLayers: []*internal.FilesystemLayer{
+var imageWindows = image{
+	url:      "https://test/v2/user/repo/manifests/v1.0",
+	platform: "windows/amd64",
+	filesystemLayers: []filesystemLayer{
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:47916aee02007e0e175e80deb2938cf8f95457b9abb555bd44dc461680dc552c",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      323887,
-			CreatedBy: `cmd /S /C mkdir "C:\\Program\ Files\\envoy"`,
+			url:       "https://test/v2/user/repo/blobs/sha256:47916aee02007e0e175e80deb2938cf8f95457b9abb555bd44dc461680dc552c",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      323887,
+			createdBy: `cmd /S /C mkdir "C:\\Program\ Files\\envoy"`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:ba79ee4428b5ceec3026664126a146fd8c1041b478f3018ec0c90b78d7fe6355",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      331919,
-			CreatedBy: `cmd /S /C setx path "%path%;c:\Program Files\envoy"`,
+			url:       "https://test/v2/user/repo/blobs/sha256:ba79ee4428b5ceec3026664126a146fd8c1041b478f3018ec0c90b78d7fe6355",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      331919,
+			createdBy: `cmd /S /C setx path "%path%;c:\Program Files\envoy"`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      12217107,
-			CreatedBy: `cmd /S /C #(nop) ADD file:61df7bfb8255c0673d4ed25f961df5121141ee800202081e549fc36828624577 in C:\Program Files\envoy\ `,
+			url:       "https://test/v2/user/repo/blobs/sha256:fd103a6c37aad8ffeaef6521612ed5a5153b104fffdb8bf3b6cf3d0beaaa49c4",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      12217107,
+			createdBy: `cmd /S /C #(nop) ADD file:61df7bfb8255c0673d4ed25f961df5121141ee800202081e549fc36828624577 in C:\Program Files\envoy\ `,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:0fcfdc906e922391139a1c2d8f5d600066fa3b21c720a4024831471e2a8f0011",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      337530,
-			CreatedBy: `cmd /S /C mkdir "C:\\ProgramData\\envoy"`,
+			url:       "https://test/v2/user/repo/blobs/sha256:0fcfdc906e922391139a1c2d8f5d600066fa3b21c720a4024831471e2a8f0011",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      337530,
+			createdBy: `cmd /S /C mkdir "C:\\ProgramData\\envoy"`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:f5ece8fbad694f5d1169c17ddd4217265cdf3dd886b71a8e9144f8b00e22de07",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      2410,
-			CreatedBy: `cmd /S /C #(nop) ADD file:59ef68147ad4a3f10999e2e334cf60397fbcc6501b3949dd811afd7b8f03ca43 in C:\ProgramData\envoy\envoy.yaml `,
+			url:       "https://test/v2/user/repo/blobs/sha256:f5ece8fbad694f5d1169c17ddd4217265cdf3dd886b71a8e9144f8b00e22de07",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      2410,
+			createdBy: `cmd /S /C #(nop) ADD file:59ef68147ad4a3f10999e2e334cf60397fbcc6501b3949dd811afd7b8f03ca43 in C:\ProgramData\envoy\envoy.yaml `,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:8d3db7768af4371ec3f749f6816c8450687e276a883b8ca626a1fc1402fd32e0",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      419457,
-			CreatedBy: `cmd /S /C powershell -Command "(cat C:\ProgramData\envoy\envoy.yaml -raw) -replace '/tmp/','C:\Windows\Temp\' | Set-Content -Encoding Ascii C:\ProgramData\envoy\envoy.yaml"`,
+			url:       "https://test/v2/user/repo/blobs/sha256:8d3db7768af4371ec3f749f6816c8450687e276a883b8ca626a1fc1402fd32e0",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      419457,
+			createdBy: `cmd /S /C powershell -Command "(cat C:\ProgramData\envoy\envoy.yaml -raw) -replace '/tmp/','C:\Windows\Temp\' | Set-Content -Encoding Ascii C:\ProgramData\envoy\envoy.yaml"`,
 		},
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:9e17bb8cfb82c53b1793341a2dfb555e63088b1594d81d2b01106fae9a8aa60b",
-			MediaType: mediaTypeDockerImageLayer,
-			Size:      1745,
-			CreatedBy: `cmd /S /C #(nop) COPY file:4e78f00367722220f515590585490fc6d785cc05e3a59a54f965431fa3ef374e in C:\ `,
+			url:       "https://test/v2/user/repo/blobs/sha256:9e17bb8cfb82c53b1793341a2dfb555e63088b1594d81d2b01106fae9a8aa60b",
+			mediaType: api.MediaTypeDockerImageLayer,
+			size:      1745,
+			createdBy: `cmd /S /C #(nop) COPY file:4e78f00367722220f515590585490fc6d785cc05e3a59a54f965431fa3ef374e in C:\ `,
 		},
 	},
 }
@@ -626,13 +626,13 @@ func TestImageManifestV1_Trivy(t *testing.T) {
 
 	require.Equal(t, imageManifestV1{
 		Config: descriptorV1{
-			MediaType: mediaTypeUnknownImageConfig,
+			MediaType: api.MediaTypeUnknownImageConfig,
 			Digest:    "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
 			Size:      2,
 		},
 		Layers: []descriptorV1{
 			{
-				MediaType: mediaTypeWasmImageLayer,
+				MediaType: api.MediaTypeWasmImageLayer,
 				Digest:    "sha256:3daa3dac086bd443acce56ffceb906993b50c5838b4489af4cd2f1e2f13af03b",
 				Size:      460018,
 				Annotations: map[string]string{
@@ -643,15 +643,15 @@ func TestImageManifestV1_Trivy(t *testing.T) {
 	}, v)
 }
 
-var imageTrivy = &internal.Image{
-	URL:      "https://test/v2/user/repo/manifests/v1.0",
-	Platform: "", // unknown
-	FilesystemLayers: []*internal.FilesystemLayer{
+var imageTrivy = image{
+	url:      "https://test/v2/user/repo/manifests/v1.0",
+	platform: "", // unknown
+	filesystemLayers: []filesystemLayer{
 		{
-			URL:       "https://test/v2/user/repo/blobs/sha256:3daa3dac086bd443acce56ffceb906993b50c5838b4489af4cd2f1e2f13af03b",
-			MediaType: mediaTypeWasmImageLayer,
-			Size:      460018,
-			FileName:  "wordpress.wasm",
+			url:       "https://test/v2/user/repo/blobs/sha256:3daa3dac086bd443acce56ffceb906993b50c5838b4489af4cd2f1e2f13af03b",
+			mediaType: api.MediaTypeWasmImageLayer,
+			size:      460018,
+			fileName:  "wordpress.wasm",
 		},
 	},
 }
@@ -661,7 +661,7 @@ func TestNewImage_Trivy(t *testing.T) {
 	require.NoError(t, json.Unmarshal(trivyVndOciImageManifestV1Json, &i))
 	var c imageConfigV1
 	require.NoError(t, json.Unmarshal(trivyVndOciUnknownConfigV1Json, &c))
-	i.URL = imageTrivy.URL
+	i.URL = imageTrivy.url
 	require.Equal(t, imageTrivy, newImage("https://test/v2/user/repo", &i, &c))
 }
 


### PR DESCRIPTION
This begins refactoring by extracting reference and Registry types to an api package, similar to how it exists in wazero. This is not in the right shape, yet, but will allow future diffs to be much smaller.