### PR TITLE
fixes auth for docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ $ ./car -tf envoyproxy/envoy-windows:v1.18.3 'Files/Program Files/envoy/envoy.ex
 Files/Program Files/envoy/envoy.exe
 
 # extract a file from an image
-$ ./car --strip-components 3 --created-by-pattern 'COPY envoy /usr/local/bin/envoy' -xvvf istio/proxyv2:1.10.3 && test -f envoy
+$ ./car --strip-components 3 --created-by-pattern 'COPY envoy /usr/local/bin/envoy' -xvvf istio/proxyv2:1.10.3 && file envoy
 https://index.docker.io/v2/istio/proxyv2/manifests/1.10.3 platform=linux/amd64 totalLayerSize: 95073366
 https://index.docker.io/v2/istio/proxyv2/blobs/sha256:5afc65eb63c65ce691cc003c8b26820b7d984181b4871a2735e92cbf69595671 size=26407160
 CreatedBy: COPY envoy /usr/local/bin/envoy # buildkit
 -rwxr-xr-x	100920696	Jul 15 14:15:57	usr/local/bin/envoy
+envoy: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, not stripped
 
 # try a platform you may no usually be able to poke
 $ ./car -tvvf chocolateyfest/chocolatey:latest

--- a/cmd/car/flags_test.go
+++ b/cmd/car/flags_test.go
@@ -157,7 +157,7 @@ func Test_referenceValue(t *testing.T) {
 		{
 			name:           "docker familiar",
 			reference:      "envoyproxy/envoy:v1.18.3",
-			expectedDomain: "docker.io",
+			expectedDomain: "index.docker.io",
 			expectedPath:   "envoyproxy/envoy",
 			expectedTag:    "v1.18.3",
 		},

--- a/internal/httpclient/http_test.go
+++ b/internal/httpclient/http_test.go
@@ -57,7 +57,7 @@ Authorization: Bearer QQ==
 		},
 		{
 			name: "Docker registry",
-			url:  "https://docker.io/v2/envoyproxy/envoy/manifests/v1.18.3",
+			url:  "https://index.docker.io/v2/envoyproxy/envoy/manifests/v1.18.3",
 			header: http.Header{
 				"Accept": []string{
 					"application/vnd.docker.distribution.manifest.list.v2+json",
@@ -66,7 +66,7 @@ Authorization: Bearer QQ==
 				"Authorization": []string{"Bearer eyJhbGciOiJSUzI1NiIsInR5cC"},
 			},
 			expectedRequests: []string{`GET /v2/envoyproxy/envoy/manifests/v1.18.3 HTTP/1.1
-Host: docker.io
+Host: index.docker.io
 Accept: application/vnd.docker.distribution.manifest.list.v2+json
 Accept: application/vnd.docker.distribution.manifest.v2+json
 Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cC

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -61,7 +61,7 @@ func Parse(ref string) (r *Reference, err error) {
 
 	// See if this is a familiar official docker image. e.g. "alpine:3.14.0"
 	if indexSlash == -1 {
-		r.domain = "docker.io"
+		r.domain = "index.docker.io"
 		r.path = "library/" + remaining
 		return
 	}
@@ -69,13 +69,19 @@ func Parse(ref string) (r *Reference, err error) {
 	// See if this is an official docker image. e.g. "envoyproxy/envoy:v1.18.3"
 	if strings.LastIndexByte(ref, byte('/')) == indexSlash &&
 		strings.IndexByte(remaining, byte('.')) == -1 {
-		r.domain = "docker.io"
+		r.domain = "index.docker.io"
 		r.path = remaining
 		return
 	}
 
 	// Otherwise, the part leading to the first slash is the domain.
 	r.domain = remaining[0:indexSlash]
+
+	// Finally, any direct reference to docker.io should use the index
+	if r.domain == "docker.io" {
+		r.domain = "index.docker.io"
+	}
+
 	r.path = remaining[indexSlash+1:]
 	return
 }

--- a/internal/reference/reference_test.go
+++ b/internal/reference/reference_test.go
@@ -25,7 +25,7 @@ func Test_Parse(t *testing.T) {
 		{
 			name:           "docker familiar",
 			reference:      "envoyproxy/envoy:v1.18.3",
-			expectedDomain: "docker.io",
+			expectedDomain: "index.docker.io",
 			expectedPath:   "envoyproxy/envoy",
 			expectedTag:    "v1.18.3",
 		},
@@ -39,21 +39,21 @@ func Test_Parse(t *testing.T) {
 		{
 			name:           "docker fully qualified",
 			reference:      "docker.io/envoyproxy/envoy:v1.18.3",
-			expectedDomain: "docker.io",
+			expectedDomain: "index.docker.io",
 			expectedPath:   "envoyproxy/envoy",
 			expectedTag:    "v1.18.3",
 		},
 		{
 			name:           "docker familiar official",
 			reference:      "alpine:3.14.0",
-			expectedDomain: "docker.io",
+			expectedDomain: "index.docker.io",
 			expectedPath:   "library/alpine",
 			expectedTag:    "3.14.0",
 		},
 		{
 			name:           "docker unfamiliar official",
 			reference:      "docker.io/library/alpine:3.14.0",
-			expectedDomain: "docker.io",
+			expectedDomain: "index.docker.io",
 			expectedPath:   "library/alpine",
 			expectedTag:    "3.14.0",
 		},

--- a/internal/registry/docker/docker_test.go
+++ b/internal/registry/docker/docker_test.go
@@ -36,7 +36,7 @@ func TestRoundTripper(t *testing.T) {
 	}
 	expectedTagList := tagList{"envoy", []string{"v1.18.1", "v1.18.2"}}
 
-	url, err := urlpkg.Parse("https://docker.io/v2/envoyproxy/envoy/manifests/list?n=100")
+	url, err := urlpkg.Parse("https://index.docker.io/v2/envoyproxy/envoy/manifests/list?n=100")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -53,7 +53,7 @@ Host: auth.docker.io
 Accept: application/json
 
 `, `GET /v2/envoyproxy/envoy/manifests/list?n=100 HTTP/1.1
-Host: docker.io
+Host: index.docker.io
 Authorization: Bearer a
 
 `}, []interface{}{tokenResponse{"a"}, expectedTagList}},
@@ -62,7 +62,7 @@ Authorization: Bearer a
 			name:   "valid",
 			docker: &bearerAuth{"a"},
 			real: &mock{t, 0, []string{`GET /v2/envoyproxy/envoy/manifests/list?n=100 HTTP/1.1
-Host: docker.io
+Host: index.docker.io
 Authorization: Bearer a
 
 `}, []interface{}{expectedTagList}},


### PR DESCRIPTION
We lost some hostname shuffling in a recent commit, which resulted in 403 on any docker image.