### PR TITLE
Removes leading slash from paths, to normalize expressions

### DIFF
--- a/internal/car/car.go
+++ b/internal/car/car.go
@@ -82,6 +82,7 @@ func (c *car) do(ctx context.Context, readFile api.ReadFile, ref api.Reference, 
 	}
 	pm := patternmatcher.New(c.filePatterns, c.fastRead)
 	rf := func(name string, size int64, mode os.FileMode, modTime time.Time, reader io.Reader) error {
+		name = stripLeadingSlash(name)
 		if !pm.MatchesPattern(name) {
 			return nil
 		}
@@ -186,4 +187,14 @@ func (c *car) getFilesystemLayers(ctx context.Context, ref api.Reference, platfo
 		}
 	}
 	return filteredLayers, nil
+}
+
+// stripLeadingSlash removes any leading slash from the input file name, to
+// normalize pattern matching. For example, paketo images have a combination of
+// relative and absolute paths in their squashed image.
+func stripLeadingSlash(name string) string {
+	if len(name) > 0 && name[0] == '/' {
+		return name[1:]
+	}
+	return name
 }

--- a/internal/registry/fake/fake.go
+++ b/internal/registry/fake/fake.go
@@ -186,7 +186,8 @@ type fakeFile struct {
 // The fake data intentionally overlaps on "usr/local" for testing. Even if weird, it adds windows paths.
 var fakeFiles = [][]*fakeFile{
 	{
-		{"bin/apple.txt", 10, 0o640 & os.ModePerm, "2020-06-07T06:28:15Z"},
+		// intentionally leading slash
+		{"/bin/apple.txt", 10, 0o640 & os.ModePerm, "2020-06-07T06:28:15Z"},
 		{"usr/local/bin/boat", 20, 0o755 & os.ModePerm, "2021-04-16T22:53:09Z"},
 	},
 	{


### PR DESCRIPTION
Paketo images have a mix of layers where some are prefixed with '/' and others aren't. This normalizes to the default ( no prefix ).


```bash
$ build/car_darwin_arm64/car --created-by-pattern='Application Slice: .*' -tvvf springcloud/spring-cloud-kubernetes-discoveryserver:3.1.0https://index.docker.io/v2/springcloud/spring-cloud-kubernetes-discoveryserver/manifests/3.1.0 platform=linux/amd64 totalLayerSize: 161698415
https://index.docker.io/v2/springcloud/spring-cloud-kubernetes-discoveryserver/blobs/sha256:7c10de33d911ff562f520769e3c09f1971e6f498981752aedea649c3a190024d size=58360080
CreatedBy: Application Slice: 1
-rw-r--r--	173763	Jan  1 08:00:01	workspace/BOOT-INF/lib/HdrHistogram-2.1.12.jar
-rw-r--r--	29779	Jan  1 08:00:01	workspace/BOOT-INF/lib/LatencyUtils-2.0.3.jar
--snip--
```