### PR TITLE
Skip sending Authorization header to r2.cloudflarestorage.com

### DIFF
--- a/internal/registry/docker/docker.go
+++ b/internal/registry/docker/docker.go
@@ -52,7 +52,11 @@ func (b *bearerAuth) RoundTrip(req *http.Request) (*http.Response, error) {
 		b.token = token
 	}
 
-	req.Header.Set("Authorization", "Bearer "+b.token)
+	// r2.cloudflarestorage.com doesn't like to see Authorization header in the request.
+	// When the Authorization header is present, it returns 400 Bad Request.
+	if !strings.HasSuffix(req.URL.Host, "r2.cloudflarestorage.com") {
+		req.Header.Set("Authorization", "Bearer "+b.token)
+	}
 	req.Header.Set("User-Agent", "") // don't add implicit User-Agent
 	return httpclient.TransportFromContext(req.Context()).RoundTrip(req)
 }


### PR DESCRIPTION
`car` fails to retrieve an image config from docker.io because Cloudflare R2, the actual storage, rejects requests with the Authorization header.

This PR ensures the Authorization header is omitted for Cloudflare R2.

Fix https://github.com/tetratelabs/car/issues/35